### PR TITLE
Écran éligibilité v4

### DIFF
--- a/app/LandingUI.tsx
+++ b/app/LandingUI.tsx
@@ -73,8 +73,8 @@ export const Labels = styled.ul`
   li {
     margin-right: 0.6rem;
     padding: 0.1rem 0.3rem;
-    color: #18753c;
-    background: #b8fec9;
+    color: ${(p) => p.$color || '#18753c'};
+    background: ${(p) => p.$background || '#b8fec9'};
     font-weight: bold;
     font-size: 90%;
     border-radius: 0.6rem;

--- a/app/règles/index.yaml
+++ b/app/règles/index.yaml
@@ -472,7 +472,6 @@ MPR . non accompagnée:
   alias: Parcours par geste
   interface:
     motivation: J’ai une idée précise des travaux à réaliser
-    action: Je choisis mes travaux
     avantages:
       - Un choix à la carte dans un bouquet de travaux subventionnés
 
@@ -495,7 +494,6 @@ MPR . accompagnée:
   alias: Parcours accompagné
   interface:
     motivation: Je veux améliorer significativement la performance de mon logement.
-    action: J'affine mon projet
     avantages:
       - Un accompagnement renforcé pour des gains réels après travaux
       - Un financement plus important

--- a/components/AutresAides.tsx
+++ b/components/AutresAides.tsx
@@ -45,6 +45,7 @@ export default function AutresAides() {
                   }
                 }
                 h4 {
+                  margin-top: 1.6rem;
                 }
                 display: flex;
                 flex-direction: column;

--- a/components/AutresAides.tsx
+++ b/components/AutresAides.tsx
@@ -1,6 +1,6 @@
 import autresAides from '@/app/règles/autres-aides.yaml'
 import { parse } from 'marked'
-import { CTA, CTAWrapper } from './UI'
+import { CTA, CTAWrapper, Card } from './UI'
 import Link from 'next/link'
 
 export default function AutresAides() {
@@ -20,6 +20,7 @@ export default function AutresAides() {
       </p>
       <ol
         css={`
+          padding-left: 0;
           list-style-type: none;
           display: flex;
           align-items: center;
@@ -32,11 +33,10 @@ export default function AutresAides() {
       >
         {autresAides.map((aide) => (
           <li key={aide.nom}>
-            <div
+            <Card
               css={`
-                border: 1px solid var(--color);
                 width: 14rem;
-                height: 16rem;
+                height: 20rem;
                 padding: 0.2rem 1rem;
                 p {
                   margin-bottom: 0.8rem 0;
@@ -66,7 +66,7 @@ export default function AutresAides() {
                   <Link href={aide.lien}>En savoir plus</Link>
                 </CTA>
               </CTAWrapper>
-            </div>
+            </Card>
           </li>
         ))}
       </ol>

--- a/components/Geste.tsx
+++ b/components/Geste.tsx
@@ -2,6 +2,7 @@ import { formatValue } from 'publicodes'
 import { getRuleName } from './publicodes/utils'
 import informationIcon from '@/public/information.svg'
 import Image from 'next/image'
+import styled from 'styled-components'
 
 export default function Geste({
   dottedName,
@@ -96,17 +97,17 @@ export default function Geste({
     </details>
   )
 }
+
+export const PrimeStyle = styled.span`
+  color: #356e3e;
+  background: #bef2c5;
+  border: 1px solid #356e3e4d;
+  padding: 0.1rem 0.4rem 0.05rem;
+  border-radius: 0.2rem;
+  white-space: nowrap;
+`
 export const Prime = ({ value }) => (
-  <strong
-    css={`
-      color: #356e3e;
-      background: #bef2c5;
-      border: 1px solid #356e3e4d;
-      padding: 0.1rem 0.4rem 0.05rem;
-      border-radius: 0.2rem;
-      white-space: nowrap;
-    `}
-  >
-    {value}
-  </strong>
+  <PrimeStyle>
+    <strong>{value}</strong>
+  </PrimeStyle>
 )

--- a/components/Geste.tsx
+++ b/components/Geste.tsx
@@ -105,6 +105,7 @@ export const PrimeStyle = styled.span`
   padding: 0.1rem 0.4rem 0.05rem;
   border-radius: 0.2rem;
   white-space: nowrap;
+  ${(p) => p.$inactive && `background: grey`}
 `
 export const Prime = ({ value }) => (
   <PrimeStyle>

--- a/components/Geste.tsx
+++ b/components/Geste.tsx
@@ -10,6 +10,7 @@ export default function Geste({
   engine,
   expanded,
   situation,
+  inactive,
 }) {
   const questionRule = rules[dottedName]
 
@@ -35,7 +36,7 @@ export default function Geste({
         >
           {questionRule.titre || getRuleName(dottedName)}
         </div>
-        <Prime value={`${montantValue}`} />
+        <Prime value={`${montantValue}`} inactive={inactive} />
       </div>
     )
   return (
@@ -66,7 +67,7 @@ export default function Geste({
       <summary>
         <div>
           <div>{questionRule.titre || getRuleName(dottedName)}</div>
-          <Prime value={`${montantValue}`} />
+          <Prime value={`${montantValue}`} inactive={inactive} />
         </div>
       </summary>
 
@@ -105,10 +106,10 @@ export const PrimeStyle = styled.span`
   padding: 0.1rem 0.4rem 0.05rem;
   border-radius: 0.2rem;
   white-space: nowrap;
-  ${(p) => p.$inactive && `background: grey`}
+  ${(p) => p.$inactive && `background: #eee; color: #666`}
 `
-export const Prime = ({ value }) => (
-  <PrimeStyle>
+export const Prime = ({ value, inactive = false }) => (
+  <PrimeStyle $inactive={inactive}>
     <strong>{value}</strong>
   </PrimeStyle>
 )

--- a/components/Geste.tsx
+++ b/components/Geste.tsx
@@ -63,6 +63,7 @@ export default function Geste({
           }
         }
       `}
+      open={true}
     >
       <summary>
         <div>

--- a/components/MPRSelector.tsx
+++ b/components/MPRSelector.tsx
@@ -105,9 +105,8 @@ export default function MPRSelector({
           <div>
             <p>
               Vous êtes éligible aux deux parcours, le parcours accompagné et le
-              parcours par gestes.
+              parcours par gestes. Vous devez choisir l'un des deux parcours.
             </p>
-            <p>Vous devez choisir l'un des deux parcours.</p>
             <Avis {...{ situation, engine }} />
           </div>
         )

--- a/components/MPRSelector.tsx
+++ b/components/MPRSelector.tsx
@@ -7,6 +7,7 @@ import AutresAides from './AutresAides'
 import { CustomQuestionWrapper } from './CustomQuestionUI'
 import Image from 'next/image'
 import checkIcon from '@/public/check.svg'
+import crossIcon from '@/public/remix-close-empty.svg'
 
 export default function MPRSelector({
   setSearchParams,
@@ -74,8 +75,16 @@ export default function MPRSelector({
             css={`
               text-decoration: underline;
               text-decoration-color: salmon;
+              display: flex;
+              align-items: center;
+              img {
+                margin-right: 0.4rem;
+                height: 1.6rem;
+                width: auto;
+              }
             `}
           >
+            <Image src={crossIcon} alt="Icône d'une croix" />
             Vous n'êtes pas éligible aux aides Ma Prime Rénov.
           </p>
 

--- a/components/Result.tsx
+++ b/components/Result.tsx
@@ -63,6 +63,10 @@ export default function Result({
         margin: 0;
         width: 22rem;
         max-width: min(22rem, 90%);
+        @media (min-width: 800px) {
+          width: 100%;
+          max-width: initial;
+        }
         border-color: ${fail ? '#ddd' : '#dfdff1'};
 
         position: relative;
@@ -72,16 +76,6 @@ export default function Result({
           margin: 2rem 0 0.4rem;
         }
         @media (min-width: 800px) {
-          margin: 0 1.5rem;
-          > section {
-            height: 40rem;
-            display: flex;
-            flex-direction: column;
-            justify-content: start;
-            > header {
-              height: 12rem;
-            }
-          }
         }
       `}
     >
@@ -195,6 +189,14 @@ export default function Result({
                 <ExplicationMPRG {...{ engine, situation }} />
               </div>
             )}
+
+            <p
+              css={`
+                margin-top: 1.4rem;
+              `}
+            >
+              Choisissez vos travaux dans un bouquet de gestes subventionnés.
+            </p>
             {!fail ? (
               <GestesPreview
                 {...{
@@ -225,7 +227,7 @@ export default function Result({
                 display: ${!isNotApplicable && url ? 'visible' : 'none'};
                 > div {
                   margin-bottom: 0.3rem;
-                  margin-top: 1rem;
+                  margin-top: 1.6rem;
                 }
               `}
             >
@@ -254,10 +256,10 @@ export const Results = styled.ul`
   padding-left: 0;
   margin-top: 1rem;
   list-style-type: none;
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
   @media (max-width: 800px) {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
     flex-direction: column;
     > span {
       margin: 0.6rem;

--- a/components/Result.tsx
+++ b/components/Result.tsx
@@ -11,6 +11,7 @@ import {
   ExplicationCommune,
   ExplicationMPRG,
 } from './explications/Éligibilité'
+import { Labels } from '@/app/LandingUI'
 
 /* This component was first written for simulation mode where the state could be success, running or fail. Since then we've switched to a more classic result where it
  * can only be success or fail. I've kept this object for future references, for its colors */
@@ -70,45 +71,33 @@ export default function Result({
 		width: 22rem;
         max-width: min(22rem, 90%);
 		background: white;
-		${cardBorder}
+		${cardBorder};
 		border-color: ${fail ? '#ddd' : '#dfdff1'};
 
 	position: relative;
 
     display: flex;
     flex-direction: column;
-    align-items: center;
+    align-items: start;
 	justify-content: space-between;
       `)}
     >
-      <span
-        css={`
-          line-height: 1.5rem;
-          left: -2px;
-          position: absolute;
-          top: 50%;
-          transform: translateY(-50%) translateX(-50%);
-          border-radius: 3rem;
-          width: 3.6rem;
-          height: 3.6rem;
-          background: white;
-          text-align: center;
-          img {
-            width: 100%;
-            height: auto;
-          }
-          z-index: 1;
-        `}
-      >
-        <Image
-          src={'/' + rule.illustration}
-          alt={'Illustration de ' + rule.titre}
-          width="20"
-          height="20"
-        />
-      </span>
+      {dottedName === 'MPR . accompagnée' && (
+        <Labels
+          $color={'#6E4444'}
+          $background={'#fdf8db'}
+          css={`
+            margin-top: 0.3rem;
+          `}
+        >
+          {['🤝 Un professionnel vous accompagne'].map((text) => (
+            <li key={text}>{text}</li>
+          ))}
+        </Labels>
+      )}
       <h3
         style={css`
+          margin-top: 1.2rem;
           font-weight: 400;
           margin: 0.15rem 0 1rem;
         `}

--- a/components/Result.tsx
+++ b/components/Result.tsx
@@ -130,8 +130,8 @@ export default function Result({
               dangerouslySetInnerHTML={{ __html: rule.titreHtml }}
             />
 
-            <PrimeStyle>
-              {isFinal ? `` : `Jusqu'à `} <strong>{value}</strong>
+            <PrimeStyle $inactive={fail}>
+              {isFinal ? `` : fail ? `` : `Jusqu'à `} <strong>{value}</strong>
             </PrimeStyle>
             <p
               css={`
@@ -186,6 +186,7 @@ export default function Result({
           <GestesPreview
             {...{
               rules,
+              inactive: fail,
               dottedNames: [
                 'gestes . recommandés . audit',
                 'gestes . chauffage . PAC . air-eau',

--- a/components/Result.tsx
+++ b/components/Result.tsx
@@ -1,17 +1,11 @@
+import { Labels } from '@/app/LandingUI'
 import css from '@/components/css/convertToJs'
 import { formatValue } from '@/node_modules/publicodes/dist/index'
-import Image from 'next/image'
 import Link from 'next/link'
 import { styled } from 'styled-components'
-import Check from './Check'
-import { Value } from './ScenariosSelector'
+import { PrimeStyle } from './Geste'
 import { CTA, CTAWrapper, cardBorder } from './UI'
-import {
-  ExplicationMPRA,
-  ExplicationCommune,
-  ExplicationMPRG,
-} from './explications/Éligibilité'
-import { Labels } from '@/app/LandingUI'
+import { ExplicationMPRA, ExplicationMPRG } from './explications/Éligibilité'
 
 /* This component was first written for simulation mode where the state could be success, running or fail. Since then we've switched to a more classic result where it
  * can only be success or fail. I've kept this object for future references, for its colors */
@@ -60,6 +54,7 @@ export default function Result({
   const state = isNotApplicable ? 'fail' : isFinal ? 'success' : 'running',
     fail = state === 'fail'
   const { color, background, label } = colors[state]
+  const MPRA = dottedName === 'MPR . accompagnée'
 
   return (
     <li
@@ -67,7 +62,6 @@ export default function Result({
 	  color: ${fail ? '#888' : 'inherit'};
         padding: 1.4rem 1.5rem;
         margin: .6rem auto;
-		height: 30rem;
 		width: 22rem;
         max-width: min(22rem, 90%);
 		background: white;
@@ -82,7 +76,7 @@ export default function Result({
 	justify-content: space-between;
       `)}
     >
-      {dottedName === 'MPR . accompagnée' && (
+      {MPRA && (
         <Labels
           $color={'#6E4444'}
           $background={'#fdf8db'}
@@ -97,92 +91,27 @@ export default function Result({
       )}
       <h3
         style={css`
-          margin-top: 1.2rem;
           font-weight: 400;
-          margin: 0.15rem 0 1rem;
+          margin: 1rem 0 0rem;
         `}
         dangerouslySetInnerHTML={{ __html: rule.titreHtml }}
       />
-      <p
-        css={`
-          img {
-            width: 1.6rem;
-            height: auto;
-            margin-right: 0.6rem;
-            opacity: 0.4;
-            margin-top: -0.3rem;
-          }
-          display: flex;
-          align-items: start;
-        `}
-      >
-        <Image
-          src="/quote-remix.svg"
-          alt="Icône citation"
-          width="10"
-          height="10"
-        />
-        {rule.interface.motivation}
-      </p>
-      <ol
-        css={`
-          margin: 1rem 0;
-          list-style-type: none;
 
-          li {
-            margin-bottom: 0.6rem;
-            display: flex;
-            align-items: center;
-            svg {
-              margin-right: 0.6rem;
-              width: 1.4rem;
-              height: auto;
-            }
-          }
-          min-height: 8rem;
-        `}
-      >
-        {rule.interface.avantages.map((avantage) => (
-          <li key={avantage}>
-            <span>
-              <Check color={fail ? '#888' : '#347c5d'} />
-            </span>
-            <span>{avantage}</span>
-          </li>
-        ))}
-      </ol>
-      <div
-        style={css(`
-          visibility: ${
-            // TODO pour l'instant, on cache la valeur numérique de ce parcours, car on sait pas trop comment l'estimer, il faudrait définir un montant pour chaque geste, des m², un nombre de fenêtres etc.
-            isNotApplicable ? 'hidden' : ''
-          };
-			${hideNumeric && !isFinal ? 'visibility: hidden;' : ''}
-          margin: 0.15rem 0;
-        `)}
-      >
-        {isFinal ? `` : `Jusqu'à `} {value}
-      </div>
-      <small
-        css={`
-          padding: 0 0.2rem;
-          margin-top: 0.1rem;
-          ${fail
-            ? `
-			font-size: 100%;
-			padding: .2rem .6rem;
-		  background: ${background}; 
-		  color: ${color};
-
-		  `
-            : `
-          text-decoration: underline dotted var(--color);
-          text-decoration-thickness: 2px;
-		  `}
-        `}
-      >
-        {label}
-      </small>
+      {MPRA && (
+        <PrimeStyle>
+          {isFinal ? `` : `Jusqu'à `} <strong>{value}</strong>
+        </PrimeStyle>
+      )}
+      {MPRA && (
+        <p
+          css={`
+            margin-top: 1.4rem;
+          `}
+        >
+          Vous serez accompagné pour rénover votre logement et gagner au minimum{' '}
+          <strong>deux classes DPE</strong>.
+        </p>
+      )}
       {fail && (
         <div
           css={`
@@ -191,7 +120,7 @@ export default function Result({
             text-align: center;
           `}
         >
-          {dottedName === 'MPR . non accompagnée' ? (
+          {!MPRA ? (
             <ExplicationMPRG {...{ engine, situation }} />
           ) : (
             <ExplicationMPRA {...{ engine, situation }} />
@@ -201,11 +130,17 @@ export default function Result({
       <div
         css={`
           visibility: ${!isNotApplicable && url ? 'visible' : 'hidden'};
+          > div {
+            margin-bottom: 0.3rem;
+            margin-top: 1rem;
+          }
         `}
       >
         <CTAWrapper>
           <CTA $fontSize="normal">
-            <Link href={url}>{rule.interface.action}</Link>
+            <Link href={url}>
+              {MPRA ? 'Découvrir le détail' : 'Voir les 20 gestes disponibles'}
+            </Link>
           </CTA>
         </CTAWrapper>
       </div>

--- a/components/Result.tsx
+++ b/components/Result.tsx
@@ -183,20 +183,40 @@ export default function Result({
               <ExplicationMPRG {...{ engine, situation }} />
             </div>
           )}
-          <GestesPreview
-            {...{
-              rules,
-              inactive: fail,
-              dottedNames: [
-                'gestes . recommandés . audit',
-                'gestes . chauffage . PAC . air-eau',
-                'gestes . isolation . murs extérieurs',
-                'gestes . isolation . murs intérieurs',
-              ],
-              engine,
-              situation,
-            }}
-          />
+          {!fail ? (
+            <GestesPreview
+              {...{
+                rules,
+                inactive: fail,
+                dottedNames: [
+                  'gestes . recommandés . audit',
+                  'gestes . chauffage . PAC . air-eau',
+                  'gestes . isolation . murs extérieurs',
+                  'gestes . isolation . murs intérieurs',
+                ],
+                engine,
+                situation,
+              }}
+            />
+          ) : (
+            <details>
+              <summary>Détails</summary>
+              <GestesPreview
+                {...{
+                  rules,
+                  inactive: fail,
+                  dottedNames: [
+                    'gestes . recommandés . audit',
+                    'gestes . chauffage . PAC . air-eau',
+                    'gestes . isolation . murs extérieurs',
+                    'gestes . isolation . murs intérieurs',
+                  ],
+                  engine,
+                  situation,
+                }}
+              />
+            </details>
+          )}
           <div
             css={`
               visibility: ${!isNotApplicable && url ? 'visible' : 'hidden'};

--- a/components/Result.tsx
+++ b/components/Result.tsx
@@ -140,8 +140,8 @@ export default function Result({
                 margin-top: 1.4rem;
               `}
             >
-              Vous serez accompagné pour rénover votre logement et gagner au
-              minimum <strong>deux classes DPE</strong>.
+              Un programme sur-mesure pour gagner au minimum{' '}
+              <strong>deux&nbsp;classes&nbsp;DPE</strong>.
             </p>
             <div
               css={`

--- a/components/Result.tsx
+++ b/components/Result.tsx
@@ -4,7 +4,7 @@ import { formatValue } from '@/node_modules/publicodes/dist/index'
 import Link from 'next/link'
 import { styled } from 'styled-components'
 import { PrimeStyle } from './Geste'
-import { CTA, CTAWrapper, cardBorder } from './UI'
+import { CTA, CTAWrapper, Card, cardBorder } from './UI'
 import { ExplicationMPRA, ExplicationMPRG } from './explications/Éligibilité'
 
 /* This component was first written for simulation mode where the state could be success, running or fail. Since then we've switched to a more classic result where it
@@ -58,92 +58,139 @@ export default function Result({
 
   return (
     <li
-      style={css(`
-	  color: ${fail ? '#888' : 'inherit'};
-        padding: 1.4rem 1.5rem;
-        margin: .6rem auto;
-		width: 22rem;
+      css={`
+        color: ${fail ? '#888' : 'inherit'};
+        margin: 0;
+        width: 22rem;
         max-width: min(22rem, 90%);
-		background: white;
-		${cardBorder};
-		border-color: ${fail ? '#ddd' : '#dfdff1'};
+        border-color: ${fail ? '#ddd' : '#dfdff1'};
 
-	position: relative;
+        position: relative;
 
-    display: flex;
-    flex-direction: column;
-    align-items: start;
-	justify-content: space-between;
-      `)}
+        h3 {
+          font-size: 120%;
+          margin: 2rem 0 0.4rem;
+        }
+      `}
     >
-      {MPRA && (
-        <Labels
-          $color={'#6E4444'}
-          $background={'#fdf8db'}
-          css={`
-            margin-top: 0.3rem;
-          `}
-        >
-          {['🤝 Un professionnel vous accompagne'].map((text) => (
-            <li key={text}>{text}</li>
-          ))}
-        </Labels>
-      )}
-      <h3
-        style={css`
-          font-weight: 400;
-          margin: 1rem 0 0rem;
-        `}
-        dangerouslySetInnerHTML={{ __html: rule.titreHtml }}
-      />
+      {' '}
+      {MPRA ? (
+        <section>
+          <h3>L'État vous accompagne</h3>
+          <p>L'aide principale en 2024 pour rénover son logement.</p>
+          <Card
+            css={`
+              background: white;
+            `}
+          >
+            <Labels
+              $color={'#6E4444'}
+              $background={'#fdf8db'}
+              css={`
+                margin-top: 0.3rem;
+              `}
+            >
+              {['🤝 Un professionnel vous accompagne'].map((text) => (
+                <li key={text}>{text}</li>
+              ))}
+            </Labels>
+            <h4
+              style={css`
+                font-weight: 400;
+                margin: 1rem 0 0rem;
+                font-size: 120%;
+              `}
+              dangerouslySetInnerHTML={{ __html: rule.titreHtml }}
+            />
 
-      {MPRA && (
-        <PrimeStyle>
-          {isFinal ? `` : `Jusqu'à `} <strong>{value}</strong>
-        </PrimeStyle>
-      )}
-      {MPRA && (
-        <p
-          css={`
-            margin-top: 1.4rem;
-          `}
-        >
-          Vous serez accompagné pour rénover votre logement et gagner au minimum{' '}
-          <strong>deux classes DPE</strong>.
-        </p>
-      )}
-      {fail && (
-        <div
-          css={`
-            margin: 1rem 0;
-            color: black;
-            text-align: center;
-          `}
-        >
-          {!MPRA ? (
-            <ExplicationMPRG {...{ engine, situation }} />
-          ) : (
-            <ExplicationMPRA {...{ engine, situation }} />
+            <PrimeStyle>
+              {isFinal ? `` : `Jusqu'à `} <strong>{value}</strong>
+            </PrimeStyle>
+            <p
+              css={`
+                margin-top: 1.4rem;
+              `}
+            >
+              Vous serez accompagné pour rénover votre logement et gagner au
+              minimum <strong>deux classes DPE</strong>.
+            </p>
+            {fail && (
+              <div
+                css={`
+                  margin: 1rem 0;
+                  color: black;
+                  text-align: center;
+                `}
+              >
+                <ExplicationMPRA {...{ engine, situation }} />
+              </div>
+            )}
+            <div
+              css={`
+                visibility: ${!isNotApplicable && url ? 'visible' : 'hidden'};
+                > div {
+                  margin-bottom: 0.3rem;
+                  margin-top: 1rem;
+                }
+              `}
+            >
+              <CTAWrapper $justify="start">
+                <CTA $fontSize="normal">
+                  <Link href={url}>
+                    {MPRA
+                      ? 'Découvrir le détail'
+                      : 'Voir les 20 gestes disponibles'}
+                  </Link>
+                </CTA>
+              </CTAWrapper>
+            </div>
+          </Card>
+        </section>
+      ) : (
+        <section>
+          <h3>Les aides à la carte</h3>
+          <p>
+            Vous pouvez autrement être aidé pour rénover plus progressivement
+            votre logement.
+          </p>
+
+          {fail && (
+            <div
+              css={`
+                margin: 1rem 0;
+                color: black;
+                text-align: center;
+              `}
+            >
+              <ExplicationMPRG {...{ engine, situation }} />
+            </div>
           )}
-        </div>
+
+          <div
+            css={`
+              visibility: ${!isNotApplicable && url ? 'visible' : 'hidden'};
+              > div {
+                margin-bottom: 0.3rem;
+                margin-top: 1rem;
+              }
+            `}
+          >
+            <CTAWrapper $justify="start">
+              <CTA $fontSize="normal">
+                <Link href={url}>
+                  {MPRA ? (
+                    'Découvrir le détail'
+                  ) : (
+                    <span>
+                      Voir les <strong>20</strong> gestes disponibles
+                    </span>
+                  )}
+                </Link>
+              </CTA>
+            </CTAWrapper>
+          </div>
+        </section>
       )}
-      <div
-        css={`
-          visibility: ${!isNotApplicable && url ? 'visible' : 'hidden'};
-          > div {
-            margin-bottom: 0.3rem;
-            margin-top: 1rem;
-          }
-        `}
-      >
-        <CTAWrapper>
-          <CTA $fontSize="normal">
-            <Link href={url}>
-              {MPRA ? 'Découvrir le détail' : 'Voir les 20 gestes disponibles'}
-            </Link>
-          </CTA>
-        </CTAWrapper>
-      </div>
     </li>
   )
 }

--- a/components/Result.tsx
+++ b/components/Result.tsx
@@ -91,7 +91,9 @@ export default function Result({
         <section>
           <header>
             <h3>L'État vous accompagne</h3>
-            <p>L'aide principale en 2024 pour rénover son logement.</p>
+            <p>
+              L'aide principale en 2024 pour faire une rénovation d'ampleur.
+            </p>
           </header>
           {fail && (
             <div
@@ -166,41 +168,29 @@ export default function Result({
         <section>
           <header>
             <h3>Les aides à la carte</h3>
-            <p>
-              Vous pouvez autrement être aidé pour rénover plus progressivement
-              votre logement.
-            </p>
+            <p>Rénovez progressivement votre logement.</p>
           </header>
-
-          {fail && (
-            <div
-              css={`
-                margin: 1rem 0;
-                color: black;
-                text-align: center;
+          <Card>
+            <h4
+              style={css`
+                font-weight: 400;
+                margin: 1rem 0 0rem;
+                font-size: 120%;
               `}
-            >
-              <ExplicationMPRG {...{ engine, situation }} />
-            </div>
-          )}
-          {!fail ? (
-            <GestesPreview
-              {...{
-                rules,
-                inactive: fail,
-                dottedNames: [
-                  'gestes . recommandés . audit',
-                  'gestes . chauffage . PAC . air-eau',
-                  'gestes . isolation . murs extérieurs',
-                  'gestes . isolation . murs intérieurs',
-                ],
-                engine,
-                situation,
-              }}
+              dangerouslySetInnerHTML={{ __html: rule.titreHtml }}
             />
-          ) : (
-            <details>
-              <summary>Détails</summary>
+            {fail && (
+              <div
+                css={`
+                  margin: 1rem 0;
+                  color: black;
+                  text-align: center;
+                `}
+              >
+                <ExplicationMPRG {...{ engine, situation }} />
+              </div>
+            )}
+            {!fail ? (
               <GestesPreview
                 {...{
                   rules,
@@ -209,37 +199,54 @@ export default function Result({
                     'gestes . recommandés . audit',
                     'gestes . chauffage . PAC . air-eau',
                     'gestes . isolation . murs extérieurs',
-                    'gestes . isolation . murs intérieurs',
                   ],
                   engine,
                   situation,
                 }}
               />
-            </details>
-          )}
-          <div
-            css={`
-              visibility: ${!isNotApplicable && url ? 'visible' : 'hidden'};
-              > div {
-                margin-bottom: 0.3rem;
-                margin-top: 1rem;
-              }
-            `}
-          >
-            <CTAWrapper $justify="start">
-              <CTA $fontSize="normal">
-                <Link href={url}>
-                  {MPRA ? (
-                    'Découvrir le détail'
-                  ) : (
-                    <span>
-                      Voir les <strong>20</strong> gestes disponibles
-                    </span>
-                  )}
-                </Link>
-              </CTA>
-            </CTAWrapper>
-          </div>
+            ) : (
+              <details>
+                <summary>Détails</summary>
+                <GestesPreview
+                  {...{
+                    rules,
+                    inactive: fail,
+                    dottedNames: [
+                      'gestes . recommandés . audit',
+                      'gestes . chauffage . PAC . air-eau',
+                      'gestes . isolation . murs extérieurs',
+                      'gestes . isolation . murs intérieurs',
+                    ],
+                    engine,
+                    situation,
+                  }}
+                />
+              </details>
+            )}
+            <div
+              css={`
+                visibility: ${!isNotApplicable && url ? 'visible' : 'hidden'};
+                > div {
+                  margin-bottom: 0.3rem;
+                  margin-top: 1rem;
+                }
+              `}
+            >
+              <CTAWrapper $justify="start">
+                <CTA $fontSize="normal">
+                  <Link href={url}>
+                    {MPRA ? (
+                      'Découvrir le détail'
+                    ) : (
+                      <span>
+                        Voir les <strong>20</strong> gestes disponibles
+                      </span>
+                    )}
+                  </Link>
+                </CTA>
+              </CTAWrapper>
+            </div>
+          </Card>
         </section>
       )}
     </li>

--- a/components/Result.tsx
+++ b/components/Result.tsx
@@ -93,6 +93,17 @@ export default function Result({
             <h3>L'État vous accompagne</h3>
             <p>L'aide principale en 2024 pour rénover son logement.</p>
           </header>
+          {fail && (
+            <div
+              css={`
+                margin: 1rem 0;
+                color: black;
+                text-align: center;
+              `}
+            >
+              <ExplicationMPRA {...{ engine, situation }} />
+            </div>
+          )}
           <Card
             css={`
               margin-top: 0.2rem;
@@ -130,17 +141,6 @@ export default function Result({
               Vous serez accompagné pour rénover votre logement et gagner au
               minimum <strong>deux classes DPE</strong>.
             </p>
-            {fail && (
-              <div
-                css={`
-                  margin: 1rem 0;
-                  color: black;
-                  text-align: center;
-                `}
-              >
-                <ExplicationMPRA {...{ engine, situation }} />
-              </div>
-            )}
             <div
               css={`
                 visibility: ${!isNotApplicable && url ? 'visible' : 'hidden'};

--- a/components/Result.tsx
+++ b/components/Result.tsx
@@ -60,7 +60,6 @@ export default function Result({
   return (
     <li
       css={`
-        color: ${fail ? '#888' : 'inherit'};
         margin: 0;
         width: 22rem;
         max-width: min(22rem, 90%);
@@ -95,19 +94,9 @@ export default function Result({
               L'aide principale en 2024 pour faire une rénovation d'ampleur.
             </p>
           </header>
-          {fail && (
-            <div
-              css={`
-                margin: 1rem 0;
-                color: black;
-                text-align: center;
-              `}
-            >
-              <ExplicationMPRA {...{ engine, situation }} />
-            </div>
-          )}
           <Card
             css={`
+              color: ${fail ? '#888' : 'inherit'};
               margin-top: 0.2rem;
               background: white;
             `}
@@ -132,9 +121,21 @@ export default function Result({
               dangerouslySetInnerHTML={{ __html: rule.titreHtml }}
             />
 
-            <PrimeStyle $inactive={fail}>
-              {isFinal ? `` : fail ? `` : `Jusqu'à `} <strong>{value}</strong>
-            </PrimeStyle>
+            {fail ? (
+              <div
+                css={`
+                  margin: 1rem 0;
+                  color: black;
+                  text-align: center;
+                `}
+              >
+                <ExplicationMPRA {...{ engine, situation }} />
+              </div>
+            ) : (
+              <PrimeStyle $inactive={fail}>
+                {isFinal ? `` : fail ? `` : `Jusqu'à `} <strong>{value}</strong>
+              </PrimeStyle>
+            )}
             <p
               css={`
                 margin-top: 1.4rem;
@@ -170,7 +171,11 @@ export default function Result({
             <h3>Les aides à la carte</h3>
             <p>Rénovez progressivement votre logement.</p>
           </header>
-          <Card>
+          <Card
+            css={`
+              color: ${fail ? '#888' : 'inherit'};
+            `}
+          >
             <h4
               style={css`
                 font-weight: 400;
@@ -205,27 +210,19 @@ export default function Result({
                 }}
               />
             ) : (
-              <details>
-                <summary>Détails</summary>
-                <GestesPreview
-                  {...{
-                    rules,
-                    inactive: fail,
-                    dottedNames: [
-                      'gestes . recommandés . audit',
-                      'gestes . chauffage . PAC . air-eau',
-                      'gestes . isolation . murs extérieurs',
-                      'gestes . isolation . murs intérieurs',
-                    ],
-                    engine,
-                    situation,
-                  }}
-                />
-              </details>
+              <span>
+                <a
+                  target="_blank"
+                  href="https://www.service-public.fr/particuliers/vosdroits/F35083"
+                >
+                  En savoir plus sur ce parcours
+                </a>
+                .
+              </span>
             )}
             <div
               css={`
-                visibility: ${!isNotApplicable && url ? 'visible' : 'hidden'};
+                display: ${!isNotApplicable && url ? 'visible' : 'none'};
                 > div {
                   margin-bottom: 0.3rem;
                   margin-top: 1rem;

--- a/components/Result.tsx
+++ b/components/Result.tsx
@@ -6,6 +6,7 @@ import { styled } from 'styled-components'
 import { PrimeStyle } from './Geste'
 import { CTA, CTAWrapper, Card, cardBorder } from './UI'
 import { ExplicationMPRA, ExplicationMPRG } from './explications/Éligibilité'
+import GestesPreview from './mprg/GestesPreview'
 
 /* This component was first written for simulation mode where the state could be success, running or fail. Since then we've switched to a more classic result where it
  * can only be success or fail. I've kept this object for future references, for its colors */
@@ -165,7 +166,19 @@ export default function Result({
               <ExplicationMPRG {...{ engine, situation }} />
             </div>
           )}
-
+          <GestesPreview
+            {...{
+              rules,
+              dottedNames: [
+                'gestes . recommandés . audit',
+                'gestes . chauffage . PAC . air-eau',
+                'gestes . isolation . murs extérieurs',
+                'gestes . isolation . murs intérieurs',
+              ],
+              engine,
+              situation,
+            }}
+          />
           <div
             css={`
               visibility: ${!isNotApplicable && url ? 'visible' : 'hidden'};

--- a/components/Result.tsx
+++ b/components/Result.tsx
@@ -72,15 +72,30 @@ export default function Result({
           font-size: 120%;
           margin: 2rem 0 0.4rem;
         }
+        @media (min-width: 800px) {
+          margin: 0 1.5rem;
+          > section {
+            height: 40rem;
+            display: flex;
+            flex-direction: column;
+            justify-content: start;
+            > header {
+              height: 12rem;
+            }
+          }
+        }
       `}
     >
       {' '}
       {MPRA ? (
         <section>
-          <h3>L'État vous accompagne</h3>
-          <p>L'aide principale en 2024 pour rénover son logement.</p>
+          <header>
+            <h3>L'État vous accompagne</h3>
+            <p>L'aide principale en 2024 pour rénover son logement.</p>
+          </header>
           <Card
             css={`
+              margin-top: 0.2rem;
               background: white;
             `}
           >
@@ -149,11 +164,13 @@ export default function Result({
         </section>
       ) : (
         <section>
-          <h3>Les aides à la carte</h3>
-          <p>
-            Vous pouvez autrement être aidé pour rénover plus progressivement
-            votre logement.
-          </p>
+          <header>
+            <h3>Les aides à la carte</h3>
+            <p>
+              Vous pouvez autrement être aidé pour rénover plus progressivement
+              votre logement.
+            </p>
+          </header>
 
           {fail && (
             <div

--- a/components/ScenariosSelector.tsx
+++ b/components/ScenariosSelector.tsx
@@ -49,7 +49,7 @@ export default function ScenariosSelector({
           situation,
         }}
       />
-      {oldIndex < 2 && (
+      {oldIndex < 2 ? (
         <Card
           css={`
             margin: 0.6rem 0;
@@ -58,90 +58,72 @@ export default function ScenariosSelector({
           👌 Votre logement est trop performant (A&nbsp;ou&nbsp;B) pour
           bénéficier du parcours accompagné.
         </Card>
-      )}
-      <DPEScenario
-        {...{ rules, choice, oldIndex, engine, situation, setSearchParams }}
-      />
-
-      <section
-        css={`
-          margin-top: 2vh !important;
-
-          header {
-            display: flex;
-            align-items: center;
-            h4 {
-              color: #0359bf;
-              margin: 0;
-
-              font-weight: 500;
-            }
-            margin-bottom: 1.5vh !important;
-          }
-          ul li {
-            margin: 0.6rem 0;
-          }
-        `}
-      >
-        <header>
-          <Image
-            src={informationIcon}
-            width="25"
-            css={`
-              margin-right: 0.4rem;
-            `}
+      ) : (
+        <>
+          <DPEScenario
+            {...{ rules, choice, oldIndex, engine, situation, setSearchParams }}
           />
-          <h4>Informations utiles</h4>
-        </header>
-        <ul>
-          <li>
-            Un Accompagnateur Rénov’ réalisera un audit énergétique de votre
-            logement pour définir le projet de travaux vous permettant
-            d’atteindre le DPE visé.{' '}
-            <a href="https://france-renov.gouv.fr/preparer-projet/faire-accompagner/mon-accompagnateur-renov">
-              En savoir plus
-            </a>
-            .
-          </li>
-          <li>
-            <Avance {...{ engine, rules, situation, choice }} />
-          </li>
-          <li>
-            <p>
-              Vous êtes éligible à l'
-              <a href="https://france-renov.gouv.fr/aides/eco-pret-taux-zero">
-                éco-prêt à taux zéro
-              </a>{' '}
-              pour emprunter jusqu'à 50 000 € sur 20 ans.
-            </p>
-          </li>
-        </ul>
-      </section>
-      <h3>Comment toucher cette aide ?</h3>
-      <ol
-        css={`
-          padding-left: 0;
-          list-style-type: none;
-          header {
-            display: flex;
-            align-items: center;
-            h3 {
-              margin: 0;
-              margin-left: 0.6rem;
-            }
-            margin-bottom: 1vh;
-          }
-          li > section {
-            margin-left: 2.4rem;
-          }
-        `}
-      >
-        <li>
-          <header>
-            <Number>1</Number>
-            <h3>Vous avez encore des questions ?</h3>
-          </header>
-          <section>
+
+          <section
+            css={`
+              margin-top: 2vh !important;
+
+              header {
+                display: flex;
+                align-items: center;
+                h4 {
+                  color: #0359bf;
+                  margin: 0;
+
+                  font-weight: 500;
+                }
+                margin-bottom: 1.5vh !important;
+              }
+              ul li {
+                margin: 0.6rem 0;
+              }
+            `}
+          >
+            <header>
+              <Image
+                src={informationIcon}
+                width="25"
+                css={`
+                  margin-right: 0.4rem;
+                `}
+              />
+              <h4>Informations utiles</h4>
+            </header>
+            <ul>
+              <li>
+                Un Accompagnateur Rénov’ réalisera un audit énergétique de votre
+                logement pour définir le projet de travaux vous permettant
+                d’atteindre le DPE visé.{' '}
+                <a href="https://france-renov.gouv.fr/preparer-projet/faire-accompagner/mon-accompagnateur-renov">
+                  En savoir plus
+                </a>
+                .
+              </li>
+              <li>
+                <Avance {...{ engine, rules, situation, choice }} />
+              </li>
+              <li>
+                <p>
+                  Vous êtes éligible à l'
+                  <a href="https://france-renov.gouv.fr/aides/eco-pret-taux-zero">
+                    éco-prêt à taux zéro
+                  </a>{' '}
+                  pour emprunter jusqu'à 50 000 € sur 20 ans.
+                </p>
+              </li>
+            </ul>
+          </section>
+        </>
+      )}
+      {oldIndex < 2 ? (
+        <section>
+          <h3>Vous avez encore des questions ?</h3>
+          <div>
             <p>
               Votre conseiller local France Rénov’ vous accompagne{' '}
               <strong>gratuitement</strong> et sans engagement.
@@ -155,32 +137,76 @@ export default function ScenariosSelector({
                 link: 'https://france-renov.gouv.fr/preparer-projet/trouver-conseiller#trouver-un-espace-conseil-france-renov',
               }}
             />
-          </section>
-        </li>
-        <li>
-          <header>
-            <Number>2</Number>
-            <h3>Vous voulez lancer votre projet ?</h3>
-          </header>
-          <section>
-            <p>
-              Choisissez votre Accompagnateur Rénov’, l’interlocuteur de
-              confiance agréé par France Rénov’ qui vous accompagne de
-              bout-en-bout dans votre parcours de travaux.
-            </p>
+          </div>
+        </section>
+      ) : (
+        <>
+          <h3>Comment toucher cette aide ?</h3>
+          <ol
+            css={`
+              padding-left: 0;
+              list-style-type: none;
+              header {
+                display: flex;
+                align-items: center;
+                h3 {
+                  margin: 0;
+                  margin-left: 0.6rem;
+                }
+                margin-bottom: 1vh;
+              }
+              li > section {
+                margin-left: 2.4rem;
+              }
+            `}
+          >
+            <li>
+              <header>
+                <Number>1</Number>
+                <h3>Vous avez encore des questions ?</h3>
+              </header>
+              <section>
+                <p>
+                  Votre conseiller local France Rénov’ vous accompagne{' '}
+                  <strong>gratuitement</strong> et sans engagement.
+                </p>
+                <MapBehindCTA
+                  {...{
+                    codeInsee: situation['ménage . commune']?.replace(/'/g, ''),
 
-            <MapBehindCTA
-              {...{
-                codeInsee: situation['ménage . commune']?.replace(/'/g, ''),
+                    what: 'trouver-conseiller-renov',
+                    text: 'Trouver mon conseiller',
+                    link: 'https://france-renov.gouv.fr/preparer-projet/trouver-conseiller#trouver-un-espace-conseil-france-renov',
+                  }}
+                />
+              </section>
+            </li>
+            <li>
+              <header>
+                <Number>2</Number>
+                <h3>Vous voulez lancer votre projet ?</h3>
+              </header>
+              <section>
+                <p>
+                  Choisissez votre Accompagnateur Rénov’, l’interlocuteur de
+                  confiance agréé par France Rénov’ qui vous accompagne de
+                  bout-en-bout dans votre parcours de travaux.
+                </p>
 
-                text: 'Trouver mon accompagnateur',
-                link: 'https://france-renov.gouv.fr/preparer-projet/trouver-conseiller#trouver-un-espace-conseil-france-renov',
-                importance: 'emptyBackground',
-              }}
-            />
-          </section>
-        </li>
-      </ol>
+                <MapBehindCTA
+                  {...{
+                    codeInsee: situation['ménage . commune']?.replace(/'/g, ''),
+
+                    text: 'Trouver mon accompagnateur',
+                    link: 'https://france-renov.gouv.fr/preparer-projet/trouver-conseiller#trouver-un-espace-conseil-france-renov',
+                    importance: 'emptyBackground',
+                  }}
+                />
+              </section>
+            </li>
+          </ol>
+        </>
+      )}
       <QuestionsRéponses
         {...{
           engine,

--- a/components/ScenariosSelector.tsx
+++ b/components/ScenariosSelector.tsx
@@ -26,7 +26,8 @@ export default function ScenariosSelector({
 
   const value = situation['projet . DPE visé'],
     oldIndex = +situation['DPE . actuel'] - 1,
-    choice = value ? value - 1 : Math.max(oldIndex - 2, 0)
+    automaticChoice = Math.max(oldIndex - 2, 0),
+    choice = value ? Math.min(automaticChoice, value - 1) : automaticChoice
 
   return (
     <CustomQuestionWrapper>

--- a/components/ScenariosSelector.tsx
+++ b/components/ScenariosSelector.tsx
@@ -237,7 +237,21 @@ export const Value = ({ engine, situation, dottedName, state = 'none' }) => {
 
   return (
     <Key $state={state || (missing.length > 0 ? 'inProgress' : 'final')}>
-      {missing.length > 0 ? '...' : value}
+      {missing.length > 0 ? (
+        <span
+          css={`
+            display: inline-block;
+            padding: 0 1rem;
+            background: var(--lighterColor);
+            border-radius: 0.3rem;
+            font-weight: 300;
+          `}
+        >
+          ... €
+        </span>
+      ) : (
+        value
+      )}
     </Key>
   )
 }

--- a/components/ScenariosSelector.tsx
+++ b/components/ScenariosSelector.tsx
@@ -78,6 +78,9 @@ export default function ScenariosSelector({
             }
             margin-bottom: 1.5vh !important;
           }
+          ul li {
+            margin: 0.6rem 0;
+          }
         `}
       >
         <header>
@@ -90,23 +93,29 @@ export default function ScenariosSelector({
           />
           <h4>Informations utiles</h4>
         </header>
-        <p>
-          Un Accompagnateur Rénov’ réalisera un audit énergétique de votre
-          logement pour définir le projet de travaux vous permettant d’atteindre
-          le DPE visé.{' '}
-          <a href="https://france-renov.gouv.fr/preparer-projet/faire-accompagner/mon-accompagnateur-renov">
-            En savoir plus
-          </a>
-          .
-        </p>
-        <Avance {...{ engine, rules, situation, choice }} />
-        <p>
-          Vous êtes éligible à l'
-          <a href="https://france-renov.gouv.fr/aides/eco-pret-taux-zero">
-            éco-prêt à taux zéro
-          </a>{' '}
-          pour emprunter jusqu'à 50 000 € sur 20 ans.
-        </p>
+        <ul>
+          <li>
+            Un Accompagnateur Rénov’ réalisera un audit énergétique de votre
+            logement pour définir le projet de travaux vous permettant
+            d’atteindre le DPE visé.{' '}
+            <a href="https://france-renov.gouv.fr/preparer-projet/faire-accompagner/mon-accompagnateur-renov">
+              En savoir plus
+            </a>
+            .
+          </li>
+          <li>
+            <Avance {...{ engine, rules, situation, choice }} />
+          </li>
+          <li>
+            <p>
+              Vous êtes éligible à l'
+              <a href="https://france-renov.gouv.fr/aides/eco-pret-taux-zero">
+                éco-prêt à taux zéro
+              </a>{' '}
+              pour emprunter jusqu'à 50 000 € sur 20 ans.
+            </p>
+          </li>
+        </ul>
       </section>
       <h3>Comment toucher cette aide ?</h3>
       <ol

--- a/components/UI.tsx
+++ b/components/UI.tsx
@@ -72,7 +72,6 @@ export const TopBanner = styled.p`
 `
 
 export const CTAWrapper = styled.div`
-  text-align: right;
   margin: 3vh 0;
   display: flex;
   align-items: center;
@@ -82,6 +81,7 @@ export const CTAWrapper = styled.div`
   }
   > div:last-child {
     margin-right: 0;
+  }
   }
 `
 export const CTA = styled.div`

--- a/components/UI.tsx
+++ b/components/UI.tsx
@@ -16,7 +16,7 @@ export const Section = styled.section`
 `
 export const cardBorder = `
 
-  padding: 1.2vh calc(.4rem + 1vw);
+  padding: 1.2vh calc(.5rem + 1vw);
   border: 2px solid #dfdff1;
   border-radius: 0.3rem;
 `

--- a/components/explications/Éligibilité.tsx
+++ b/components/explications/Éligibilité.tsx
@@ -1,5 +1,8 @@
 import DPELabel from '../DPELabel'
 import { Value } from '../ScenariosSelector'
+import Image from 'next/image'
+import checkIcon from '@/public/check.svg'
+import crossIcon from '@/public/remix-close-empty.svg'
 
 export function ExplicationMPRA({ situation, engine }) {
   const dpeActuel = situation['DPE . actuel']
@@ -16,19 +19,34 @@ export function ExplicationMPRA({ situation, engine }) {
   const sauts = engine.evaluate('sauts')
   if (sauts.nodeValue < 2)
     return (
-      <p>
-        💡 Votre projet de {sauts.nodeValue} sauts de DPE{' '}
-        <span
-          css={`
-            white-space: nowrap;
-          `}
-        >
-          (de <DPELabel index={situation['DPE . actuel'] - 1} />
-          &nbsp;à&nbsp;
-          <DPELabel index={situation['projet . DPE visé'] - 1} />)
-        </span>{' '}
-        est insuffisant.
-      </p>
+      <div
+        css={`
+          text-decoration: underline;
+          text-decoration-color: salmon;
+          display: flex;
+          align-items: center;
+          img {
+            margin-right: 0.4rem;
+            height: 1.6rem;
+            width: auto;
+          }
+        `}
+      >
+        <Image src={crossIcon} alt="Icône d'une croix" />
+        <p>
+          Votre projet de {sauts.nodeValue} sauts de DPE{' '}
+          <span
+            css={`
+              white-space: nowrap;
+            `}
+          >
+            (de <DPELabel index={situation['DPE . actuel'] - 1} />
+            &nbsp;à&nbsp;
+            <DPELabel index={situation['projet . DPE visé'] - 1} />)
+          </span>{' '}
+          est insuffisant.
+        </p>
+      </div>
     )
 }
 
@@ -64,7 +82,7 @@ export function ExplicationMPRG({ situation, engine }) {
             }}
           />{' '}
         </span>{' '}
-        dépasse le seuil.
+        dépasse le seuil d'éligibilité.
       </p>
     )
 }

--- a/components/explications/Éligibilité.tsx
+++ b/components/explications/Éligibilité.tsx
@@ -48,13 +48,13 @@ export function ExplicationMPRG({ situation, engine }) {
   if (revenu)
     return (
       <p>
-        💡 Votre revenu de {revenu} €{' '}
+        💡 Votre revenu de{' '}
         <span
           css={`
             white-space: nowrap;
           `}
         >
-          (classe{' '}
+          classe{' '}
           <Value
             {...{
               engine,
@@ -63,7 +63,6 @@ export function ExplicationMPRG({ situation, engine }) {
               state: 'final',
             }}
           />{' '}
-          )
         </span>{' '}
         dépasse le seuil.
       </p>

--- a/components/explications/Éligibilité.tsx
+++ b/components/explications/Éligibilité.tsx
@@ -3,35 +3,42 @@ import { Value } from '../ScenariosSelector'
 import Image from 'next/image'
 import checkIcon from '@/public/check.svg'
 import crossIcon from '@/public/remix-close-empty.svg'
+import styled from 'styled-components'
 
+export const InapplicableBlock = styled.div`
+  text-decoration: underline;
+  text-decoration-color: salmon;
+  display: flex;
+  align-items: center;
+  img {
+    margin-right: 0.6rem;
+    height: 1.6rem;
+    width: auto;
+  }
+  p {
+    text-align: left;
+    margin: 0;
+  }
+`
 export function ExplicationMPRA({ situation, engine }) {
   const dpeActuel = situation['DPE . actuel']
 
   if (dpeActuel < 3)
     return (
-      <p>
-        💡 Votre DPE {' '}
-        <DPELabel index={dpeActuel - 1} />
-        {' '}
-        est déjà trop performant.
-      </p>
+      <InapplicableBlock>
+        <Image src={crossIcon} alt="Icône d'une croix" />
+        <p>
+          Votre DPE {' '}
+          <DPELabel index={dpeActuel - 1} />
+          {' '}
+          est déjà trop performant.
+        </p>
+      </InapplicableBlock>
     )
   const sauts = engine.evaluate('sauts')
   if (sauts.nodeValue < 2)
     return (
-      <div
-        css={`
-          text-decoration: underline;
-          text-decoration-color: salmon;
-          display: flex;
-          align-items: center;
-          img {
-            margin-right: 0.4rem;
-            height: 1.6rem;
-            width: auto;
-          }
-        `}
-      >
+      <InapplicableBlock>
         <Image src={crossIcon} alt="Icône d'une croix" />
         <p>
           Votre projet de {sauts.nodeValue} sauts de DPE{' '}
@@ -46,7 +53,7 @@ export function ExplicationMPRA({ situation, engine }) {
           </span>{' '}
           est insuffisant.
         </p>
-      </div>
+      </InapplicableBlock>
     )
 }
 
@@ -54,10 +61,13 @@ export function ExplicationCommune({ situation, engine }) {
   const commune = engine.evaluate('conditions communes')
   if (!commune.nodeValue)
     return (
-      <p>
-        💡 Vous devez être propriétaire du logement, qui doit être une résidence
-        principale, construite il y a au moins 15 ans.
-      </p>
+      <InapplicableBlock>
+        <Image src={crossIcon} alt="Icône d'une croix" />
+        <p>
+          Vous devez être propriétaire du logement, qui doit être une résidence
+          principale, construite il y a au moins 15 ans.
+        </p>
+      </InapplicableBlock>
     )
   return null
 }
@@ -65,25 +75,28 @@ export function ExplicationMPRG({ situation, engine }) {
   const revenu = situation['ménage . revenu']
   if (revenu)
     return (
-      <p>
-        💡 Votre revenu de{' '}
-        <span
-          css={`
-            white-space: nowrap;
-          `}
-        >
-          classe{' '}
-          <Value
-            {...{
-              engine,
-              situation,
-              dottedName: 'ménage . revenu . classe',
-              state: 'final',
-            }}
-          />{' '}
-        </span>{' '}
-        dépasse le seuil d'éligibilité.
-      </p>
+      <InapplicableBlock>
+        <Image src={crossIcon} alt="Icône d'une croix" />
+        <p>
+          Votre revenu de{' '}
+          <span
+            css={`
+              white-space: nowrap;
+            `}
+          >
+            classe{' '}
+            <Value
+              {...{
+                engine,
+                situation,
+                dottedName: 'ménage . revenu . classe',
+                state: 'final',
+              }}
+            />{' '}
+          </span>{' '}
+          dépasse le seuil d'éligibilité.
+        </p>
+      </InapplicableBlock>
     )
 }
 

--- a/components/explications/Éligibilité.tsx
+++ b/components/explications/Éligibilité.tsx
@@ -48,16 +48,24 @@ export function ExplicationMPRG({ situation, engine }) {
   if (revenu)
     return (
       <p>
-        💡 Votre revenu de {revenu} (classe{' '}
-        <Value
-          {...{
-            engine,
-            situation,
-            dottedName: 'ménage . revenu . classe',
-            state: 'final',
-          }}
-        />{' '}
-        ) dépasse le seuil.
+        💡 Votre revenu de {revenu} €{' '}
+        <span
+          css={`
+            white-space: nowrap;
+          `}
+        >
+          (classe{' '}
+          <Value
+            {...{
+              engine,
+              situation,
+              dottedName: 'ménage . revenu . classe',
+              state: 'final',
+            }}
+          />{' '}
+          )
+        </span>{' '}
+        dépasse le seuil.
       </p>
     )
 }

--- a/components/mpra/DPEScenario.tsx
+++ b/components/mpra/DPEScenario.tsx
@@ -56,9 +56,12 @@ export default function DPEScenario({
         <div
           css={`
             text-align: left;
-            max-width: 40rem;
+            margin: 0 1rem;
             p {
               margin: 0.6rem 0;
+            }
+            h3 {
+              margin-top: 1rem;
             }
           `}
         >

--- a/components/mpra/DPEScenario.tsx
+++ b/components/mpra/DPEScenario.tsx
@@ -1,10 +1,12 @@
 import { motion } from 'framer-motion'
 import DPELabel from '../DPELabel'
 import Input from '../Input'
-import { Avance, Value } from '../ScenariosSelector'
+import { Value } from '../ScenariosSelector'
 import { Card } from '../UI'
 import { encodeSituation } from '../publicodes/situationUtils'
 import Image from 'next/image'
+
+import calculatorIcon from '@/public/calculator-empty.svg'
 
 export default function DPEScenario({
   rules,
@@ -105,43 +107,59 @@ export default function DPEScenario({
               }
             `}
           >
-            <p>
-              Par exemple : si vous apportez{' '}
-              <label>
-                <Input
-                  autoFocus={false}
-                  value={situation['projet . investissement'] || undefined}
-                  placeholder="votre apport"
-                  onChange={(rawValue) => {
-                    const value = +rawValue === 0 ? undefined : rawValue
-                    setSearchParams(
-                      encodeSituation({
-                        'projet . investissement': value,
-                      }),
-                      'replace',
-                      false,
-                    )
+            <div
+              css={`
+                display: flex;
+                align-items: center;
+              `}
+            >
+              <Image
+                src={calculatorIcon}
+                alt="Icône calculette"
+                css={`
+                  width: 2.2rem !important;
+                  height: auto !important;
+                  margin-right: 0.8rem !important;
+                `}
+              />
+              <p>
+                À vos calculs : si j'apporte{' '}
+                <label>
+                  <Input
+                    autoFocus={false}
+                    value={situation['projet . investissement'] || undefined}
+                    placeholder="mon apport"
+                    onChange={(rawValue) => {
+                      const value = +rawValue === 0 ? undefined : rawValue
+                      setSearchParams(
+                        encodeSituation({
+                          'projet . investissement': value,
+                        }),
+                        'replace',
+                        false,
+                      )
+                    }}
+                    step="100"
+                  />
+                  &nbsp;€
+                </label>
+                <span>
+                  , je pourrai entreprendre des travaux d'un montant total de{' '}
+                </span>
+                <Value
+                  {...{
+                    engine,
+                    choice,
+                    situation: {
+                      ...situation,
+                      'projet . DPE visé': choice + 1,
+                    },
+                    dottedName: 'projet . travaux',
                   }}
-                  step="100"
-                />
-                &nbsp;€
-              </label>
-              <span>
-                , vous pourrez entreprendre des travaux d'un montant total de{' '}
-              </span>
-              <Value
-                {...{
-                  engine,
-                  choice,
-                  situation: {
-                    ...situation,
-                    'projet . DPE visé': choice + 1,
-                  },
-                  dottedName: 'projet . travaux',
-                }}
-              />{' '}
-              HT.
-            </p>
+                />{' '}
+                HT.
+              </p>
+            </div>
           </div>
         </div>
       </Card>

--- a/components/mpra/DPEScenario.tsx
+++ b/components/mpra/DPEScenario.tsx
@@ -129,6 +129,7 @@ export default function DPEScenario({
                     autoFocus={false}
                     value={situation['projet . investissement'] || undefined}
                     placeholder="mon apport"
+                    min="0"
                     onChange={(rawValue) => {
                       const value = +rawValue === 0 ? undefined : rawValue
                       setSearchParams(

--- a/components/mpra/TargetDPETabs.tsx
+++ b/components/mpra/TargetDPETabs.tsx
@@ -1,8 +1,7 @@
+import dpeValues from '@/components/DPE.yaml'
 import { useMediaQuery } from 'usehooks-ts'
 import DPELabel from '../DPELabel'
-import { Value } from '../ScenariosSelector'
 import { encodeSituation } from '../publicodes/situationUtils'
-import data from '@/components/DPE.yaml'
 
 export default function TargetDPETabs({
   oldIndex,
@@ -14,7 +13,7 @@ export default function TargetDPETabs({
 }) {
   const isMobile = useMediaQuery('(max-width: 800px)')
 
-  const possibilities = data.filter((el, index) => index <= oldIndex - 2)
+  const possibilities = dpeValues.filter((el, index) => index <= oldIndex - 2)
 
   const doSetSearchParams = (question, value) => {
     const newSituation = encodeSituation(

--- a/components/mprg/GestesPreview.tsx
+++ b/components/mprg/GestesPreview.tsx
@@ -10,7 +10,11 @@ export default function GestesPreview({
 }) {
   return (
     <Fieldset>
-      <ul>
+      <ul
+        css={`
+          padding-left: 0 !important;
+        `}
+      >
         {dottedNames.map((dottedName) => (
           <li key={dottedName}>
             <Card>

--- a/components/mprg/GestesPreview.tsx
+++ b/components/mprg/GestesPreview.tsx
@@ -18,18 +18,16 @@ export default function GestesPreview({
       >
         {dottedNames.map((dottedName) => (
           <li key={dottedName}>
-            <Card>
-              <Geste
-                {...{
-                  inactive,
-                  rules,
-                  dottedName,
-                  engine,
-                  situation: { ...situation, [dottedName]: 'oui' },
-                  expanded: false,
-                }}
-              />
-            </Card>
+            <Geste
+              {...{
+                inactive,
+                rules,
+                dottedName,
+                engine,
+                situation: { ...situation, [dottedName]: 'oui' },
+                expanded: false,
+              }}
+            />
           </li>
         ))}
       </ul>

--- a/components/mprg/GestesPreview.tsx
+++ b/components/mprg/GestesPreview.tsx
@@ -1,0 +1,32 @@
+import { Fieldset } from '../BooleanMosaicUI'
+import Geste from '../Geste'
+import { Card } from '../UI'
+
+export default function GestesPreview({
+  rules,
+  dottedNames,
+  engine,
+  situation,
+}) {
+  return (
+    <Fieldset>
+      <ul>
+        {dottedNames.map((dottedName) => (
+          <li key={dottedName}>
+            <Card>
+              <Geste
+                {...{
+                  rules,
+                  dottedName,
+                  engine,
+                  situation: { ...situation, [dottedName]: 'oui' },
+                  expanded: false,
+                }}
+              />
+            </Card>
+          </li>
+        ))}
+      </ul>
+    </Fieldset>
+  )
+}

--- a/components/mprg/GestesPreview.tsx
+++ b/components/mprg/GestesPreview.tsx
@@ -7,6 +7,7 @@ export default function GestesPreview({
   dottedNames,
   engine,
   situation,
+  inactive,
 }) {
   return (
     <Fieldset>
@@ -20,6 +21,7 @@ export default function GestesPreview({
             <Card>
               <Geste
                 {...{
+                  inactive,
                   rules,
                   dottedName,
                   engine,

--- a/public/calculator-empty.svg
+++ b/public/calculator-empty.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 24 24"
+   fill="currentColor"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="calculator-empty.svg"
+   inkscape:version="1.3.1 (9b9bdc1480, 2023-11-25, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="38.875"
+     inkscape:cx="12"
+     inkscape:cy="12"
+     inkscape:window-width="1804"
+     inkscape:window-height="1178"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <path
+     d="M4 2H20C20.5523 2 21 2.44772 21 3V21C21 21.5523 20.5523 22 20 22H4C3.44772 22 3 21.5523 3 21V3C3 2.44772 3.44772 2 4 2ZM5 4V20H19V4H5ZM7 6H17V10H7V6ZM7 12H9V14H7V12ZM7 16H9V18H7V16ZM11 12H13V14H11V12ZM11 16H13V18H11V16ZM15 12H17V18H15V12Z"
+     id="path1"
+     style="fill:#d1d1fb;fill-opacity:1" />
+</svg>

--- a/public/remix-close-empty.svg
+++ b/public/remix-close-empty.svg
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 24 24"
+   fill="currentColor"
+   version="1.1"
+   id="svg1"
+   sodipodi:docname="remix-close-empty.svg"
+   inkscape:version="1.3.1 (9b9bdc1480, 2023-11-25, custom)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs1" />
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="35.5"
+     inkscape:cx="11.985915"
+     inkscape:cy="12"
+     inkscape:window-width="1920"
+     inkscape:window-height="1055"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg1" />
+  <path
+     d="M12 22C6.47715 22 2 17.5228 2 12C2 6.47715 6.47715 2 12 2C17.5228 2 22 6.47715 22 12C22 17.5228 17.5228 22 12 22ZM12 20C16.4183 20 20 16.4183 20 12C20 7.58172 16.4183 4 12 4C7.58172 4 4 7.58172 4 12C4 16.4183 7.58172 20 12 20ZM12 10.5858L14.8284 7.75736L16.2426 9.17157L13.4142 12L16.2426 14.8284L14.8284 16.2426L12 13.4142L9.17157 16.2426L7.75736 14.8284L10.5858 12L7.75736 9.17157L9.17157 7.75736L12 10.5858Z"
+     id="path1"
+     style="stroke:none;stroke-opacity:1;fill:#f7b7ae;fill-opacity:1" />
+</svg>


### PR DESCRIPTION
> :video_game: Les PR sont maintenant déployées automatiquement à cette URL facile à prédire : https://mesaidesreno-pr108.osc-fr1.scalingo.io/


Je reprends les maquettes de l'écran d'éligibilité. 

![Capture d’écran 2024-04-15 à 10 10 17](https://github.com/betagouv/reno/assets/1177762/d800ad7e-0c22-48c1-9fc8-013e996a4966)


Plus de complexité que prévu sur cet écran. Le composant qu'on avait mis en ligne intègre tous les états des aides (MPRA booléen, MPRG booléen). Donc des textes d'intro qui s'adaptent et des styles qui changent en fonction de l'éligibilité, des explications de la non éligibilité. 

J'essaie de faire une fusion de ce qui est en ligne et des maquettes, mais c'est pas simple.

Quelques points : 
- je garde le conseil MPRA pour les passoires thermiques
- je pense qu'en enlevant le texte "vous devez choisir une seule des deux aides" on omet une information clef
- j'ai changé le texte "vous pouvez également" pas "vous pouvez autrement", ça peut induire en erreur 
- On ne distingue pas visuellement le bloc d'intro Bonne nouvelle du bloc première aide "L'état vous accompagne", problème de hiérarchie de l'info. 
- il faut un titre à la page, j'ai mis "Bonne nouvelle"
- sur le bloc accompagné, on répète 4 fois le mot "accompagné" en quelques centaines de pixel, et on décrit l'aide avec 5 textes différents
- le texte "vous serez accompagné pour rénover votre logement et gagner au minimum deux classes DPE" n'est pas exact. Il y a un engagement à sauter 2 classes, mais l'accompagnement ne *garantit pas* ce saut (:/). 
- en plus de sauter aux yeux, le " :star:  recommandé", qui a le même style que le label jaune de MPRA, me donne l'impression que l'audit énergétique est une aide indépendante au même titre que MPRA