### PR TITLE
:bug: Pas de gestes dispo pour paris revenu > seuil max province

### DIFF
--- a/app/simulation/Form.tsx
+++ b/app/simulation/Form.tsx
@@ -23,7 +23,6 @@ function Form({ rules }) {
   useSyncUrlLocalStorage()
   const rawSearchParams = useSearchParams(),
     searchParams = Object.fromEntries(rawSearchParams.entries())
-  console.log('violet', searchParams)
   // this param `objectif` lets us optionally build the form to target one specific publicode rule
   const { objectif, ...situationSearchParams } = searchParams
 

--- a/app/simulation/FormButtons.tsx
+++ b/app/simulation/FormButtons.tsx
@@ -9,6 +9,7 @@ export default function FormButtons({
   encodeSituation,
   answeredQuestions,
   currentQuestion,
+  questionsToSubmit,
   situation,
   rules,
 }) {
@@ -39,7 +40,7 @@ export default function FormButtons({
                     [currentQuestion]: situation[currentQuestion],
                   },
                   false,
-                  [...answeredQuestions, currentQuestion],
+                  [...answeredQuestions, ...questionsToSubmit],
                 ),
                 question: undefined,
               },

--- a/components/ClassicQuestionWrapper.tsx
+++ b/components/ClassicQuestionWrapper.tsx
@@ -30,6 +30,7 @@ export default function ClassicQuestionWrapper({
   answeredQuestions,
   situation,
   setSearchParams,
+  questionsToSubmit = [currentQuestion],
   currentValue,
   engine,
   noSuggestions,
@@ -94,6 +95,7 @@ export default function ClassicQuestionWrapper({
                 setSearchParams,
                 encodeSituation,
                 answeredQuestions,
+                questionsToSubmit,
                 currentQuestion,
                 situation,
               }}

--- a/components/InputSwitch.tsx
+++ b/components/InputSwitch.tsx
@@ -157,6 +157,7 @@ export default function InputSwitch({
           answeredQuestions,
           situation,
           setSearchParams,
+          questionsToSubmit: ['ménage . code région', 'ménage . commune'],
           currentValue,
           engine,
         }}

--- a/utils/useSyncUrlLocalStorage.ts
+++ b/utils/useSyncUrlLocalStorage.ts
@@ -18,7 +18,6 @@ export default function useSyncUrlLocalStorage() {
 
     if (!pathname.includes('/simulation') || searchParamsString === '') return
 
-    console.log('indigo', pathname, searchParamsString)
     setSimulation(pathname + '?' + searchParamsString)
   }, [pathname, searchParamsString])
 


### PR DESCRIPTION
Bug du au fait que la réponse "code région" n'était pas validée, or
contrairement au formulaire principal, la page mosaïque des gestes
prenait seulement les réponses validées en entrée.

Pourquoi ? Parce que le formulaire décide des questions suivantes sur la
base des questions validées. Donc la question mosaïque des gestes
n'apparaissait pas du tout, le formulaire s'arrêtait.

Ce bug ne touchait donc a priori que les Franciliens au-dessus du seuil
max de revenu hors IDF qui allaient voir les gestes. Soit beaucoup de
monde quand même, statistiquement.


Fixes #119 
