### PR TITLE
optimisation question geo

### DIFF
--- a/app/règles/aides-locales.yaml
+++ b/app/règles/aides-locales.yaml
@@ -6,8 +6,9 @@ métropole d'Angers:
 
 métropole d'Angers . conditions de base:
   toutes ces conditions:
-    - logement . EPCI = '244900015'
     - logement . propriétaire occupant
+    - ménage . EPCI = '244900015' # la condition "propriétaire occupant" fait qu'on peut faire l'équivalence localisation ménage = localisation logement
+    # - logement . EPCI = '244900015' # cette condition est donc inutile
     - conditions de revenu
 
 métropole d'Angers . aides:

--- a/app/règles/index.yaml
+++ b/app/règles/index.yaml
@@ -229,6 +229,10 @@ ménage . code région:
     Pays de la Loire: '"52"'
     IdF: "'11'"
 
+ménage . EPCI:
+  formule: commune
+  par défaut: '"242900314"'
+
 ménage . commune:
   titre: Votre commune
   question: Dans quelle commune habitez-vous ?

--- a/app/simulation/Form.tsx
+++ b/app/simulation/Form.tsx
@@ -55,7 +55,7 @@ function Form({ rules }) {
       rules,
     )
 
-  console.log('blue', nextQuestions)
+  console.log('blue', { target, nextQuestions })
 
   const currentQuestion = nextQuestions[0],
     rule = currentQuestion && rules[currentQuestion]

--- a/components/InputSwitch.tsx
+++ b/components/InputSwitch.tsx
@@ -170,6 +170,7 @@ export default function InputSwitch({
                 {
                   ...situation,
                   'ménage . code région': `"${codeRegion}"`,
+                  'ménage . EPCI': `"${result.codeEpci}"`,
                   'ménage . commune': `"${result.code}"`,
                 },
                 false,


### PR DESCRIPTION
Vu que la condition propriétaire occupant est nécessaire, inutile de
poser la question de la localisation du logement.

Mais je ne comprends pas pourquoi dans ce cas la question propriétaire
occupant n'est pas posée avant l'écran MPRA !

En pratique, il y aura surement des aides qui demanderont à savoir la
localisation du logement. Donc cette interrogation est plus une
curiosité à ce stade, ou une optimisation temporaire du parcours.