### PR TITLE
Matomo v2

### DIFF
--- a/app/simulation/FormButtons.tsx
+++ b/app/simulation/FormButtons.tsx
@@ -2,6 +2,7 @@ import { isMosaicQuestion } from '@/components/BooleanMosaic'
 import { CTA, CTAWrapper } from '@/components/UI'
 import { useRouter } from 'next/navigation'
 import Link from 'next/link'
+import { push } from '@socialgouv/matomo-next'
 
 export default function FormButtons({
   currentValue,
@@ -47,6 +48,7 @@ export default function FormButtons({
               'url',
               false,
             )}
+            onClick={() => push(["trackEvent", "Simulateur Principal", "Clic", "Suivant", currentQuestion])}
             title="Aller à l'étape suivante"
           >
             Suivant

--- a/utils/Matomo.tsx
+++ b/utils/Matomo.tsx
@@ -14,7 +14,6 @@ const MatomoComponent = () => {
     }
     return () => {
       setInitialised(true)
-      push(['HeatmapSessionRecording::disable'])
     }
   }, [initialised, setInitialised])
 


### PR DESCRIPTION
Le but de cette PR est d'améliorer notre tracking matomo en utilisant des balises permettant de capter des évenements un peu partout où l'on estime cela nécessaire.

**Problème:** 
Les formulaires objectif/funnel de matomo ne permettent pas un suivi très fin: il n'est par exemple pas possible de faire des regex sur les urls dans nos funnels --> pas pratique pour nous qui en fonction des questions et suivant notre logique actuelle avons besoin de tracker des urls de type "propriétaire occupant=oui|non" avec l'astérisque en plus pour savoir si la question est définitivement validée.
C'est plus pratique de tracker le clic effectif sur le bouton Suivant en loguant la "currentQuestion", ce qui est bien plus simple en utilisant les évenements Matomo. 

Un autre intérêt est de mieux tracker le parcours utilisateur: grâce au évenement, j'espère qu'on pourra suivre d'autre type de comportement, par exemple l'utilisateur qui va sur le parcours d'ampleur, puis fait précédent et va voir le parcours par geste 