### PR TITLE
Fix sur l'affichage du footer compact

### DIFF
--- a/app/simulation/Form.tsx
+++ b/app/simulation/Form.tsx
@@ -89,7 +89,7 @@ function Form({ rules }) {
           />
         )}
       </Section>
-      {isCompact ? (<FooterCompact />) : (
+      {isInIframe && isCompact ? (<FooterCompact />) : (
         <>
           <br />
           <UserProblemBanner />


### PR DESCRIPTION
Si l'on suit le lien "J'affine ma simulation" depuis une iframe compacte, le display=contact reste dans l'url et le footer compact s'affiche