### PR TITLE
Quelques corrections de modèle

### DIFF
--- a/app/règles/index.yaml
+++ b/app/règles/index.yaml
@@ -359,7 +359,7 @@ DPE . actuel:
 
     Le DPE est exprimé comme une note de A (très bon) à G (passoire thermique). 
 
-    Si votre logement n'a pas de DPE, ou s'il date d'avant septembre 2021, date de mise en place du nouveau DPE, [il vous faudra le faire réaliser](https://www.economie.gouv.fr/particuliers/immobilier-diagnostic-performance-energetique-dpe) pour obtenir une aide MaPrimeRénov'. Son prix n'est pas réglementé mais varie entre 120 et 300 €.
+    Si votre logement n'a pas de DPE, ou s'il date d'avant septembre 2021, date de mise en place du nouveau DPE, [vous pouvez le faire réaliser](https://www.economie.gouv.fr/particuliers/immobilier-diagnostic-performance-energetique-dpe) pour un prix qui varie entre 120 et 300 €.
 
     Cela dit, **n'hésitez pas à faire une simulation avec un DPE estimé** : aucune saisie faite sur Mes Aides Réno ne vous engage à quoi que ce soit. Vous pourrez obtenir une estimation de votre DPE en 2 clics avec le service [Go Renov](https://particulier.gorenove.fr).
   par défaut: 5 # Ce DPE de départ maximise les deux aides MPR, pratique !

--- a/components/BackToLastQuestion.tsx
+++ b/components/BackToLastQuestion.tsx
@@ -9,7 +9,11 @@ import simulationConfig from '@/app/simulation/simulationConfig.yaml'
 
 const questions = simulationConfig.prioritaires
 
-export default function ({ setSearchParams, situation, answeredQuestions }) {
+export default function BackToLastQuestion({
+  setSearchParams,
+  situation,
+  answeredQuestions,
+}) {
   const [url, setUrl] = useState(null)
 
   useEffect(() => {


### PR DESCRIPTION
- **Nom d'un composant manquait**
- **Le DPE n'est plus obligatoire pour MaPrimeRénov' depuis mai 2024**
