### PR TITLE
Si l'on a pas le nombre de simulation terminee, on affiche 0

### DIFF
--- a/app/statistiques/Statistiques.tsx
+++ b/app/statistiques/Statistiques.tsx
@@ -61,9 +61,10 @@ export default function Statistiques() {
     try {
       const responseVisitors = await fetch('/api/matomo?type=visitors')
       const data = await responseVisitors.json()
+
       const weeklyData = Object.entries(data).map(([dateRange, weekData]) => ({
         date: new Date(dateRange.split(',')[1]),
-        visits: weekData[1].step_nb_visits_actual,
+        visits: weekData[1] ? weekData[1].step_nb_visits_actual : 0,
         uniqVisitors: weekData.nb_uniq_visitors,
       }))
       const totalTimeOnSite = Object.entries(data)


### PR DESCRIPTION
Parfois matomo bug/reconsolide ses stats et les chiffres ne sont plus accessibles