### PR TITLE
Ajout de BAR-TH-129

### DIFF
--- a/app/règles/gestes/chauffage.yaml
+++ b/app/règles/gestes/chauffage.yaml
@@ -5,6 +5,7 @@ chauffage:
     - raccordement réseau
     - chauffe-eau thermodynamique . montant
     - PAC . air-eau . montant
+    - PAC . air-air . montant
     - PAC . géo . montant
     - PAC . solaire . montant
     - solaire . chauffe-eau solaire . montant

--- a/app/règles/gestes/chauffage/PAC.yaml
+++ b/app/règles/gestes/chauffage/PAC.yaml
@@ -373,3 +373,143 @@ chauffage . PAC . solaire . MPR . montant:
     - si: ménage . revenu . classe = 'intermédiaire'
       alors: 6000 €
     - sinon: 0 €
+
+chauffage . PAC . air-air:
+  par défaut: oui
+  titre: Pompe à chaleur air/air
+  description: Pompe à chaleur air/air
+  technique: 'La puissance nominale de la PAC air/air est inférieure ou égale à 12 kW et son coefficient de performance saisonnier (SCOP) est supérieur ou égal à 3,9.'
+chauffage . PAC . air-air . montant:
+  applicable si: CEE . conditions
+  valeur: CEE . montant
+chauffage . PAC . air-air . CEE:
+  code: BAR-TH-129
+  titre: Pompe à chaleur de type de type air/air
+  lien: https://www.ecologie.gouv.fr/sites/default/files/documents/BAR-TH-129%20mod%20A27-3%20%C3%A0%20compter%20du%2001-04-2018.pdf
+  technique: 'La puissance nominale de la PAC air/air est inférieure ou égale à 12 kW et son coefficient de performance saisonnier (SCOP) est supérieur ou égal à 3,9.'
+chauffage . PAC . air-air . CEE . question:
+  type: liste
+  valeurs:
+    - SCOP
+chauffage . PAC . air-air . CEE . montant:
+  applicable si: CEE . conditions
+  produit:
+    - barème
+    - facteur correctif surface
+    - CEE . prix kWh Cumac
+  unité: €
+chauffage . PAC . air-air . CEE . SCOP:
+  question: Quelle serait le Coefficient de Performace (COP) de la Pompe à chaleur ?
+  titre: Efficacité énergétique saisonnière
+  par défaut: 4
+  maximum: 5
+  une possibilité parmi:
+    possibilités:
+      - 'inferieur à 4'
+      - 'inferieur à 4.3'
+      - 'superieur à 4.3'
+chauffage . PAC . air-air . CEE . SCOP . inferieur à 4:
+  valeur: '3'
+  titre: 'Inférieur à 3.9'
+chauffage . PAC . air-air . CEE . SCOP . inferieur à 4.3:
+  valeur: '4'
+  titre: 'Inférieur à 4.3'
+chauffage . PAC . air-air . CEE . SCOP . superieur à 4.3:
+  valeur: '5'
+  titre: 'Supérieur à 4.3'
+chauffage . PAC . air-air . CEE . surface: logement . surface
+chauffage . PAC . air-air . CEE . facteur correctif surface:
+  variations:
+    - si: logement . type = 'maison'
+      alors: facteur correctif surface maison
+    - sinon: facteur correctif surface appartement
+chauffage . PAC . air-air . CEE . facteur correctif surface maison:
+  variations:
+    - si: surface < 35
+      alors: 0.3
+    - si: surface < 60
+      alors: 0.5
+    - si: surface < 70
+      alors: 0.6
+    - si: surface < 90
+      alors: 0.7
+    - si: surface < 110
+      alors: 1
+    - si: surface < 130
+      alors: 1.1
+    - si: surface >= 130
+      alors: 1.6
+chauffage . PAC . air-air . CEE . facteur correctif surface appartement:
+  variations:
+    - si: surface < 35
+      alors: 0.5
+    - si: surface < 60
+      alors: 0.7
+    - si: surface < 70
+      alors: 1
+    - si: surface < 90
+      alors: 1.2
+    - si: surface < 110
+      alors: 1.5
+    - si: surface < 130
+      alors: 1.9
+    - si: surface >= 130
+      alors: 2.5
+chauffage . PAC . air-air . CEE . barème:
+  variations:
+    - si: logement . type = 'appartement'
+      alors: barème appartement
+    - si: logement . type = 'maison'
+      alors: barème maison
+chauffage . PAC . air-air . CEE . barème appartement:
+  variations:
+    - si:
+        toutes ces conditions:
+          - CEE . région = 'H1'
+          - SCOP >= 3.9
+      alors: 21300
+    - si:
+        toutes ces conditions:
+          - CEE . région = 'H2'
+          - SCOP >= 3.9
+      alors: 17400
+    - si:
+        toutes ces conditions:
+          - CEE . région = 'H3'
+          - SCOP >= 3.9
+      alors: 11600
+chauffage . PAC . air-air . CEE . barème maison:
+  variations:
+    - si:
+        toutes ces conditions:
+          - CEE . région = 'H1'
+          - SCOP >= 3.9
+          - SCOP < 4.3
+      alors: 77900
+    - si:
+        toutes ces conditions:
+          - CEE . région = 'H2'
+          - SCOP >= 3.9
+          - SCOP < 4.3
+      alors: 63700
+    - si:
+        toutes ces conditions:
+          - CEE . région = 'H3'
+          - SCOP >= 3.9
+          - SCOP < 4.3
+      alors: 42500
+    - si:
+        toutes ces conditions:
+          - CEE . région = 'H1'
+          - SCOP >= 4.3
+      alors: 80200
+    - si:
+        toutes ces conditions:
+          - CEE . région = 'H2'
+          - SCOP >= 4.3
+      alors: 65600
+    - si:
+        toutes ces conditions:
+          - CEE . région = 'H3'
+          - SCOP >= 4.3
+      alors: 43700


### PR DESCRIPTION
Implémentation de BAR-TH-129, l'aide CEE pour les pompes à chaleur air-air

Cette aide à la particularité de ne pas être éligibile dans le cadre de MaPrimeRénov'

Lien: https://www.ecologie.gouv.fr/sites/default/files/documents/BAR-TH-129%20mod%20A27-3%20%C3%A0%20compter%20du%2001-04-2018.pdf