### PR TITLE
Option d'iframe sans barre de défilement

### DIFF
--- a/components/IframeIntegrator.tsx
+++ b/components/IframeIntegrator.tsx
@@ -1,39 +1,45 @@
 'use client'
 import { BlueEm } from '@/app/LandingUI'
-import useIsInIframe from '@/components/useIsInIframe'
 import getAppUrl from '@/components/getAppUrl'
+import useIsInIframe from '@/components/useIsInIframe'
 
-export default function IframeIntegrator({iframeUrl}) {
-    const isInIframe = useIsInIframe()
-    const iframeCode = `
-        <iframe src="${getAppUrl()+iframeUrl}" style="width: 720px; height: 800px;  margin: 3rem auto; display: block; border: .2rem solid black; border-radius: 1rem;"></iframe>`
-    return (
-        !isInIframe && (
-            <>
-              <h3>Intégrer ce simulateur à votre site</h3>
-              <p>
-                Voici{' '}
-                <BlueEm>
-                  <strong>le code à intégrer</strong>
-                </BlueEm>{' '}
-                dans votre HTML ou votre contenu Wordpress :
-              </p>
-              <code css={`word-break: break-all;`}>{iframeCode}</code>
-              <h3>Le résultat</h3>
-              <div
-                css={`
-                  text-align: center;
-                  background: radial-gradient(
-                    circle,
-                    rgba(0, 0, 145, 0.2) 0%,
-                    rgba(0, 212, 255, 0) 60%,
-                    rgba(0, 212, 255, 0) 100%
-                  );
-                `}
-                dangerouslySetInnerHTML={{ __html: iframeCode}}
-              >
-              </div>
-            </>
-          )
+export default function IframeIntegrator({ iframeUrl }) {
+  const isInIframe = useIsInIframe()
+  const iframeCode = `
+        <iframe src="${getAppUrl() + iframeUrl}" style="width: 720px; height: 800px;  margin: 3rem auto; display: block; border: .2rem solid black; border-radius: 1rem;"></iframe>`
+  return (
+    !isInIframe && (
+      <>
+        <h3>Intégrer ce simulateur à votre site</h3>
+        <p>
+          Voici{' '}
+          <BlueEm>
+            <strong>le code à intégrer</strong>
+          </BlueEm>{' '}
+          dans votre HTML ou votre contenu Wordpress :
+        </p>
+        <code
+          css={`
+            word-break: break-all;
+          `}
+        >
+          {iframeCode}
+        </code>
+        <h3>Le résultato</h3>
+        <div
+          css={`
+            text-align: center;
+            background: radial-gradient(
+              circle,
+              rgba(0, 0, 145, 0.2) 0%,
+              rgba(0, 212, 255, 0) 60%,
+              rgba(0, 212, 255, 0) 100%
+            );
+          `}
+          dangerouslySetInnerHTML={{ __html: iframeCode }}
+        ></div>
+      </>
     )
+  )
 }
+

--- a/components/Integration.tsx
+++ b/components/Integration.tsx
@@ -110,11 +110,9 @@ export default function Integration() {
   const [noScroll, setNoScroll] = useState(false)
   useEffect(() => {
     if (!noScroll) return
-    console.log('listening to iframe height', 'initialize')
 
     const handleHeightChange = function (evt) {
       if (evt.data.kind === 'mesaidesreno-resize-height') {
-        console.log('listening to iframe height', evt.data.value)
         iframeRef.current.style.height = evt.data.value + 'px'
       }
     }
@@ -252,7 +250,6 @@ export default function Integration() {
 <script>
     const handleHeightChange = function (evt) {
       if (evt.data.kind === 'mesaidesreno-resize-height') {
-        console.log('listening to iframe height', evt.data.value)
         document.querySelector('iframe#mesaidesreno').current.style.height = evt.data.value + 'px'
       }
     }

--- a/components/Integration.tsx
+++ b/components/Integration.tsx
@@ -106,7 +106,10 @@ export default function Integration() {
   const iframeCode = `<iframe id="mesaidesreno" src="${getAppUrl() + module}" style="width: 400px; height: 700px; margin: 3rem auto; display: block; border: 0.2rem solid black; border-radius: 1rem;"></iframe>`
 
   const iframeRef = useRef()
+
+  const [noScroll, setNoScroll] = useState(false)
   useEffect(() => {
+    if (!noScroll) return
     console.log('listening to iframe height', 'initialize')
 
     const handleHeightChange = function (evt) {
@@ -117,7 +120,7 @@ export default function Integration() {
     }
     window.addEventListener('message', handleHeightChange)
     return () => window.removeEventListener('message', handleHeightChange)
-  }, [iframeRef])
+  }, [iframeRef, noScroll])
 
   return (
     <PageBlock>
@@ -224,6 +227,21 @@ export default function Integration() {
                   n'est pas nécessaire mais c'est possible : l'iframe prendra
                   alors une hauteur dynamique en fonction de chaque page.
                 </p>
+                <label
+                  css={`
+                    display: flex;
+                    align-items: center;
+                    gap: 0.6rem;
+                    padding: 0.6rem 0;
+                  `}
+                >
+                  <input
+                    type="checkbox"
+                    value={noScroll}
+                    onChange={() => setNoScroll(!noScroll)}
+                  />
+                  <span>Tester le redimensionnement automatique</span>
+                </label>
                 <p>
                   Cela nécessite ce petit bout de code Javascript à ajouter de
                   votre côté sur votre page hôte.

--- a/components/Integration.tsx
+++ b/components/Integration.tsx
@@ -107,12 +107,15 @@ export default function Integration() {
   const iframeRef = useRef()
   useEffect(() => {
     console.log('listening to iframe height', 'initialize')
-    window.addEventListener('message', function (evt) {
+
+    const handleHeightChange = function (evt) {
       if (evt.data.kind === 'mesaidesreno-resize-height') {
         console.log('listening to iframe height', evt.data.value)
         iframeRef.current.style.height = evt.data.value + 'px'
       }
-    })
+    }
+    window.addEventListener('message', handleHeightChange)
+    return () => window.removeEventListener('message', handleHeightChange)
   }, [iframeRef])
   return (
     <PageBlock>

--- a/components/Integration.tsx
+++ b/components/Integration.tsx
@@ -8,7 +8,7 @@ import illustrationAccueil from '@/public/illustration-accueil.resized.webp'
 import { Content, Wrapper } from '@/components/explications/ExplicationUI'
 import getAppUrl from './getAppUrl'
 import { PageBlock, Intro, CTAWrapper, CTA, MiseEnAvant } from './UI'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { Select } from './InputUI'
 import AmpleurDemonstration from '@/app/module/AmpleurDemonstration'
 import { useRouter, useSearchParams } from 'next/navigation'
@@ -104,6 +104,16 @@ export default function Integration() {
 
   const iframeCode = `<iframe src="${getAppUrl() + module}" style="width: 400px; height: 700px; margin: 3rem auto; display: block; border: 0.2rem solid black; border-radius: 1rem;"></iframe>`
 
+  const iframeRef = useRef()
+  useEffect(() => {
+    console.log('listening to iframe height', 'initialize')
+    window.addEventListener('message', function (evt) {
+      if (evt.data.kind === 'mesaidesreno-resize-height') {
+        console.log('listening to iframe height', evt.data.value)
+        iframeRef.current.style.height = evt.data.value + 'px'
+      }
+    })
+  }, [iframeRef])
   return (
     <PageBlock>
       <HeaderWrapper>
@@ -211,6 +221,7 @@ export default function Integration() {
               >
                 <p>[votre contenu]</p>
                 <iframe
+                  ref={iframeRef}
                   src={getAppUrl() + module}
                   style={css`
                     width: 400px;

--- a/components/Integration.tsx
+++ b/components/Integration.tsx
@@ -12,6 +12,7 @@ import { useEffect, useRef, useState } from 'react'
 import { Select } from './InputUI'
 import AmpleurDemonstration from '@/app/module/AmpleurDemonstration'
 import { useRouter, useSearchParams } from 'next/navigation'
+import styled from 'styled-components'
 
 export default function Integration() {
   const router = useRouter()
@@ -102,7 +103,7 @@ export default function Integration() {
       }),
     )
 
-  const iframeCode = `<iframe src="${getAppUrl() + module}" style="width: 400px; height: 700px; margin: 3rem auto; display: block; border: 0.2rem solid black; border-radius: 1rem;"></iframe>`
+  const iframeCode = `<iframe id="mesaidesreno" src="${getAppUrl() + module}" style="width: 400px; height: 700px; margin: 3rem auto; display: block; border: 0.2rem solid black; border-radius: 1rem;"></iframe>`
 
   const iframeRef = useRef()
   useEffect(() => {
@@ -117,6 +118,7 @@ export default function Integration() {
     window.addEventListener('message', handleHeightChange)
     return () => window.removeEventListener('message', handleHeightChange)
   }, [iframeRef])
+
   return (
     <PageBlock>
       <HeaderWrapper>
@@ -202,13 +204,46 @@ export default function Integration() {
                 </BlueEm>{' '}
                 dans votre HTML ou votre contenu Wordpress :
               </p>
-              <code
-                css={`
-                  word-break: break-all;
-                `}
-              >
-                {iframeCode}
-              </code>
+              <IframeCodeWrapper>
+                <code
+                  css={`
+                    word-break: break-all;
+                  `}
+                >
+                  {iframeCode}
+                </code>
+              </IframeCodeWrapper>
+              <br />
+              <br />
+              <details>
+                <summary>
+                  Comment cacher la barre de défilement verticale ?
+                </summary>
+                <p>
+                  Si vous désirez supprimer la barre de défilement verticale, ce
+                  n'est pas nécessaire mais c'est possible : l'iframe prendra
+                  alors une hauteur dynamique en fonction de chaque page.
+                </p>
+                <p>
+                  Cela nécessite ce petit bout de code Javascript à ajouter de
+                  votre côté sur votre page hôte.
+                </p>
+                <IframeCodeWrapper>
+                  <code>{` 
+
+<script>
+    const handleHeightChange = function (evt) {
+      if (evt.data.kind === 'mesaidesreno-resize-height') {
+        console.log('listening to iframe height', evt.data.value)
+        document.querySelector('iframe#mesaidesreno').current.style.height = evt.data.value + 'px'
+      }
+    }
+
+    window.addEventListener('message', handleHeightChange)
+	</script>
+					  `}</code>
+                </IframeCodeWrapper>
+              </details>
               <h2>Le résultat</h2>
 
               <div
@@ -365,3 +400,9 @@ export const ContactIntegration = ({ type }) => (
     </Content>
   </Wrapper>
 )
+
+const IframeCodeWrapper = styled.div`
+  background: white;
+  padding: 0.2rem 0.6rem;
+  border-radius: 0.4rem;
+`

--- a/components/Integration.tsx
+++ b/components/Integration.tsx
@@ -405,4 +405,5 @@ const IframeCodeWrapper = styled.div`
   background: white;
   padding: 0.2rem 0.6rem;
   border-radius: 0.4rem;
+  border: 1px solid #eee;
 `

--- a/components/useIsInIframe.ts
+++ b/components/useIsInIframe.ts
@@ -1,33 +1,53 @@
 'use client'
 
-import { useSearchParams } from 'next/navigation';
-import { useState, useEffect } from 'react';
+import { useSearchParams } from 'next/navigation'
+import { useState, useEffect } from 'react'
 
 export default function useIsInIframe() {
-  const [isInIframe, setIsInIframe] = useState(false);
+  const [isInIframe, setIsInIframe] = useState(false)
 
   useEffect(() => {
+    let observer
     if (typeof window !== 'undefined' && window.self !== window.top) {
-      setIsInIframe(true);
-    } else {
-      setIsInIframe(false);
-    }
-  }, []);
+      setIsInIframe(true)
 
-  return isInIframe;
-};
+      // The code below communicate with the iframe.js script on a host site
+      // to automatically resize the iframe when its inner content height
+      // change.
+      const minHeight = 700
+      observer = new ResizeObserver(([entry]) => {
+        const value = Math.max(minHeight, entry.contentRect.height)
+        window.parent?.postMessage(
+          { kind: 'mesaidesreno-resize-height', value },
+          '*',
+        )
+      })
+      observer.observe(window.document.body)
+    } else {
+      setIsInIframe(false)
+    }
+  }, [])
+
+  return isInIframe
+}
 
 // Certains partenaires souhaitent une version plus compacte du simulateur pour l'afficher en iframe
 // On propose cette version en rajoutant ?display=compact dans l'url
 export function useIsCompact() {
-  const [isCompact, setIsCompact] = useState(false);
-  let params = new URLSearchParams(typeof window !== 'undefined' ? window.location.search : "/");
+  const [isCompact, setIsCompact] = useState(false)
+  let params = new URLSearchParams(
+    typeof window !== 'undefined' ? window.location.search : '/',
+  )
   useEffect(() => {
-    setIsCompact(params.has('display') && params.get('display') == "compact");
-    if(params.has('color')) {
-      document.documentElement.style.setProperty('--color', `#${params.get('color')}`);
+    setIsCompact(params.has('display') && params.get('display') == 'compact')
+    if (params.has('color')) {
+      document.documentElement.style.setProperty(
+        '--color',
+        `#${params.get('color')}`,
+      )
     }
-  }, []);
+  }, [])
 
-  return isCompact;
+  return isCompact
 }
+

--- a/components/useIsInIframe.ts
+++ b/components/useIsInIframe.ts
@@ -16,7 +16,7 @@ export default function useIsInIframe() {
       // change.
       const minHeight = 700
       observer = new ResizeObserver(([entry]) => {
-        const value = Math.max(minHeight, entry.contentRect.height)
+        const value = Math.max(minHeight, entry.contentRect.height + 10) // without this 6 padding, the scroll bar will still be present
         window.parent?.postMessage(
           { kind: 'mesaidesreno-resize-height', value },
           '*',

--- a/components/useIsInIframe.ts
+++ b/components/useIsInIframe.ts
@@ -23,6 +23,7 @@ export default function useIsInIframe() {
         )
       })
       observer.observe(window.document.body)
+      // TODO return observer.disconnect this triggers an error, I don't know why
     } else {
       setIsInIframe(false)
     }
@@ -50,4 +51,3 @@ export function useIsCompact() {
 
   return isCompact
 }
-


### PR DESCRIPTION
- **Première implémentation basique de la hauteur dynamique de l'iframe**
- **Avertissement sur un effet de bord pas nettoyé**
- **Nettoyage de l'effet côté hôte**
- **Marge de 10 pour éviter la barre de défilement**
- **Instruction d'intégration du redimensionnement**
- **Style du conteneur de code**
- **Démo du redimensionnement automatique**

Démo 

![Recording 2025-02-05 at 17 32 15](https://github.com/user-attachments/assets/43a6c6ac-94b2-4a30-a2da-6dec907a1a40)

