### PR TITLE
Amélioration bouton de copie de simulation

### DIFF
--- a/components/Eligibility.tsx
+++ b/components/Eligibility.tsx
@@ -11,6 +11,7 @@ import BackToLastQuestion from './BackToLastQuestion'
 import { useAides } from './ampleur/useAides'
 import { Main, PageBlock, Section } from './UI'
 import { push } from '@socialgouv/matomo-next'
+import CopyButton from './CopyButton'
 
 export default function Eligibility({
   setSearchParams,
@@ -48,9 +49,17 @@ export default function Eligibility({
         engine={engine}
       />
       <CustomQuestionWrapper>
-        <BackToLastQuestion
-          {...{ setSearchParams, situation, answeredQuestions }}
-        />
+        <div
+          css={`
+            display: flex;
+            justify-content: space-between;
+          `}
+        >
+          <BackToLastQuestion
+            {...{ setSearchParams, situation, answeredQuestions }}
+          />
+          <CopyButton searchParams={searchParams} />
+        </div>
         <header>
           <small>Eligibilité</small>
           <h2

--- a/components/GestesMosaic.tsx
+++ b/components/GestesMosaic.tsx
@@ -12,6 +12,7 @@ import BtnBackToParcoursChoice from './BtnBackToParcoursChoice'
 import Feedback from '@/app/contact/Feedback'
 import { push } from '@socialgouv/matomo-next'
 import { AvanceTMO } from './mprg/BlocAideMPR'
+import CopyButton from './CopyButton'
 
 const localIsMosaic = (dottedName, rule) =>
   dottedName.startsWith('gestes . ') &&
@@ -36,6 +37,7 @@ export default function GestesMosaic({
   setSearchParams,
   situation,
   answeredQuestions,
+  searchParams,
   questions,
   engine,
 }) {
@@ -102,13 +104,21 @@ export default function GestesMosaic({
   return (
     <Section>
       <CustomQuestionWrapper>
-        <BtnBackToParcoursChoice
-          {...{
-            setSearchParams,
-            situation: omit(["parcours d'aide"], situation),
-            answeredQuestions,
-          }}
-        />
+        <div
+          css={`
+            display: flex;
+            justify-content: space-between;
+          `}
+        >
+          <BtnBackToParcoursChoice
+            {...{
+              setSearchParams,
+              situation: omit(["parcours d'aide"], situation),
+              answeredQuestions,
+            }}
+          />
+          <CopyButton searchParams={searchParams} />
+        </div>
         <header>
           <small>Les aides à la carte</small>
           <h2>Quels travaux souhaitez-vous entreprendre ?</h2>

--- a/components/InputSwitch.tsx
+++ b/components/InputSwitch.tsx
@@ -301,6 +301,7 @@ export default function InputSwitch({
           situation,
           answeredQuestions,
           setSearchParams,
+          searchParams,
           questions: gestesMosaicQuestions,
         }}
       />


### PR DESCRIPTION
Nous avons redesigné le bouton de copie du lien de la simulation.

En faisant ça, nous avons perdu la possibilité pour l'utilisateur de donner son accord sur le partage de ses données de simulation.
Si l'utilisateur donne son accord, nous pouvons partager l'url telle quelle (qui contient par exemple une fourchette de son RFR), sinon on partage simplement l'url de MesAidesRéno.

Cette PR vise donc à restaurer cette fonctionnalité ainsi qu'à implémenter (voire uniformiser) ce bouton sur toutes les pages nécessaires:
-  questionnaire
-  éligibilité
-  parcours ampleur
-  carte ampleur
-  parcours par geste
-  carte geste