### PR TITLE
Page "/analyses" pour la prez Rules as Cod

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ public/mesaidesreno.model.json
 mesaidesreno.model.json
 index.d.ts
 index.js
+.aider*

--- a/app/analyses/Analyses.tsx
+++ b/app/analyses/Analyses.tsx
@@ -1,3 +1,38 @@
+import { useEffect, useState } from 'react'
+import Engine from 'publicodes'
+import rules from 'mesaidesreno'
+
 export default function Analyses() {
-  return <section></section>
+  const [result, setResult] = useState<string | null>(null)
+  const [randomRevenu, setRandomRevenu] = useState<number>(0)
+
+  useEffect(() => {
+    // Générer un revenu aléatoire entre 10000 et 100000
+    const revenu = Math.floor(Math.random() * 90000) + 10000
+    setRandomRevenu(revenu)
+
+    // Initialiser le moteur publicodes avec les règles de mesaidesreno
+    const engine = new Engine(rules)
+    
+    // Définir la situation avec le revenu aléatoire
+    engine.setSituation({
+      'revenu': revenu
+    })
+    
+    // Évaluer la règle "MPR . accompagnée . montant"
+    const evaluation = engine.evaluate('MPR . accompagnée . montant')
+    
+    // Récupérer le résultat formaté
+    setResult(evaluation.nodeValue !== null ? 
+      `${evaluation.nodeValue} ${evaluation.unit || ''}` : 
+      'Règle non applicable')
+  }, [])
+
+  return (
+    <section>
+      <h2>Analyse de la règle "MPR . accompagnée . montant"</h2>
+      <p>Revenu aléatoire utilisé: {randomRevenu} €</p>
+      <p>Résultat de l'évaluation: {result || 'Calcul en cours...'}</p>
+    </section>
+  )
 }

--- a/app/analyses/Analyses.tsx
+++ b/app/analyses/Analyses.tsx
@@ -1,10 +1,13 @@
 import Engine from 'publicodes'
 import rules from 'mesaidesreno'
 
+// Initialiser le moteur publicodes une seule fois avec les règles de mesaidesreno
+const engine = new Engine(rules)
+
 // Fonction utilitaire pour évaluer une règle publicodes
 function evaluatePublicodesRule(ruleName: string, situation: Record<string, any>) {
-  // Initialiser le moteur publicodes avec les règles de mesaidesreno
-  const engine = new Engine(rules)
+  // Réinitialiser la situation pour éviter les effets de bord
+  engine.resetSituation()
   
   // Définir la situation
   engine.setSituation(situation)

--- a/app/analyses/Analyses.tsx
+++ b/app/analyses/Analyses.tsx
@@ -1,20 +1,20 @@
 import Engine from 'publicodes'
 import rules from '@/app/règles/rules'
 
-// Initialiser le moteur publicodes une seule fois avec les règles de mesaidesreno
+// Initialize the publicodes engine once with mesaidesreno rules
 const engine = new Engine(rules)
 
-// Fonction utilitaire pour évaluer une règle publicodes
+// Utility function to evaluate a publicodes rule
 function evaluatePublicodesRule(
   ruleName: string,
   situation: Record<string, any>,
 ) {
-  // Réinitialiser la situation pour éviter les effets de bord
+  // Reset the situation to avoid side effects
 
-  // Définir la situation
+  // Set the situation
   engine.setSituation(situation)
 
-  // Évaluer la règle
+  // Evaluate the rule
   const evaluation = engine.evaluate(ruleName)
 
   return {
@@ -22,28 +22,28 @@ function evaluatePublicodesRule(
     formatted:
       evaluation.nodeValue !== null
         ? `${evaluation.nodeValue} ${evaluation.unit || ''}`
-        : 'Règle non applicable',
+        : 'Rule not applicable',
     missingVariables: evaluation.missingVariables,
   }
 }
 
 export default function Analyses() {
-  // Générer un revenu aléatoire entre 10000 et 100000
+  // Generate a random income between 10000 and 100000
   const randomRevenu = Math.floor(Math.random() * 90000) + 10000
 
-  // Évaluer la règle "MPR . accompagnée . montant" avec le revenu aléatoire
+  // Evaluate the rule "MPR . accompagnée . montant" with the random income
   const result = evaluatePublicodesRule('MPR . accompagnée . montant', {
     'ménage . revenu': randomRevenu,
   })
 
   return (
     <section>
-      <h2>Analyse de la règle "MPR . accompagnée . montant"</h2>
-      <p>Revenu aléatoire utilisé: {randomRevenu} €</p>
-      <p>Résultat de l'évaluation: {result.formatted}</p>
+      <h2>Analysis of the rule "MPR . accompagnée . montant"</h2>
+      <p>Random income used: {randomRevenu} €</p>
+      <p>Evaluation result: {result.formatted}</p>
       {Object.keys(result.missingVariables).length > 0 && (
         <div>
-          <p>Variables manquantes pour le calcul complet:</p>
+          <p>Missing variables for complete calculation:</p>
           <ul>
             {Object.keys(result.missingVariables).map((variable) => (
               <li key={variable}>{variable}</li>

--- a/app/analyses/Analyses.tsx
+++ b/app/analyses/Analyses.tsx
@@ -1,6 +1,17 @@
 import Engine, { formatValue } from 'publicodes'
 import rules from '@/app/règles/rules'
 import baseSituation from '@/app/analyses/baseSituation.yaml'
+import dynamic from 'next/dynamic'
+
+// Importer recharts avec dynamic import pour éviter les problèmes SSR
+const BarChart = dynamic(() => import('recharts').then(mod => mod.BarChart), { ssr: false })
+const Bar = dynamic(() => import('recharts').then(mod => mod.Bar), { ssr: false })
+const XAxis = dynamic(() => import('recharts').then(mod => mod.XAxis), { ssr: false })
+const YAxis = dynamic(() => import('recharts').then(mod => mod.YAxis), { ssr: false })
+const CartesianGrid = dynamic(() => import('recharts').then(mod => mod.CartesianGrid), { ssr: false })
+const Tooltip = dynamic(() => import('recharts').then(mod => mod.Tooltip), { ssr: false })
+const Legend = dynamic(() => import('recharts').then(mod => mod.Legend), { ssr: false })
+const ResponsiveContainer = dynamic(() => import('recharts').then(mod => mod.ResponsiveContainer), { ssr: false })
 
 // Initialize the publicodes engine once with mesaidesreno rules
 const engine = new Engine(rules)
@@ -25,31 +36,87 @@ function evaluatePublicodesRule(
   }
 }
 
+// Function to generate revenue values from 1000 to 100000
+function generateRevenueValues(count: number) {
+  const min = 1000;
+  const max = 100000;
+  const step = (max - min) / (count - 1);
+  
+  return Array.from({ length: count }, (_, i) => Math.round(min + i * step));
+}
+
+// Function to evaluate a rule for multiple revenue values
+function evaluateRuleForMultipleRevenues(ruleName: string, revenueValues: number[]) {
+  return revenueValues.map(revenue => {
+    const result = evaluatePublicodesRule(ruleName, {
+      ...baseSituation,
+      'ménage . revenu': revenue,
+    });
+    
+    return {
+      revenue: revenue,
+      montant: typeof result.value === 'number' ? result.value : 0,
+      formatted: result.formatted,
+    };
+  });
+}
+
 export default function Analyses() {
-  // Generate a random income between 10000 and 100000
-  const randomRevenu = Math.floor(Math.random() * 90000) + 10000
-
-  // Evaluate the rule "MPR . accompagnée . montant" with the random income
-  const result = evaluatePublicodesRule('MPR . accompagnée . montant', {
-    ...baseSituation,
-    'ménage . revenu': randomRevenu,
-  })
-
+  // Generate 10 revenue values from 1000 to 100000
+  const revenueValues = generateRevenueValues(10);
+  
+  // Evaluate the rule for each revenue value
+  const results = evaluateRuleForMultipleRevenues('MPR . accompagnée . montant', revenueValues);
+  
   return (
     <section>
-      <h2>Analysis of the rule "MPR . accompagnée . montant"</h2>
-      <p>Random income used: {randomRevenu} €</p>
-      <p>Evaluation result: {result.formatted}</p>
-      {Object.keys(result.missingVariables).length > 0 && (
-        <div>
-          <p>Missing variables for complete calculation:</p>
-          <ul>
-            {Object.keys(result.missingVariables).map((variable) => (
-              <li key={variable}>{variable}</li>
-            ))}
-          </ul>
-        </div>
-      )}
+      <h2>Analyse de la règle "MPR . accompagnée . montant"</h2>
+      <p>Montant de l'aide en fonction du revenu du ménage</p>
+      
+      <div style={{ width: '100%', height: 500, marginTop: 20 }}>
+        {typeof window !== 'undefined' && (
+          <ResponsiveContainer width="100%" height="100%">
+            <BarChart
+              layout="vertical"
+              data={results}
+              margin={{ top: 20, right: 30, left: 100, bottom: 5 }}
+            >
+              <CartesianGrid strokeDasharray="3 3" />
+              <XAxis type="number" label={{ value: 'Montant (€)', position: 'insideBottom', offset: -5 }} />
+              <YAxis 
+                type="category" 
+                dataKey="revenue" 
+                tickFormatter={(value) => `${value.toLocaleString('fr-FR')} €`}
+                label={{ value: 'Revenu du ménage (€)', angle: -90, position: 'insideLeft' }}
+              />
+              <Tooltip 
+                formatter={(value) => [`${value.toLocaleString('fr-FR')} €`, 'Montant de l\'aide']}
+                labelFormatter={(value) => `Revenu: ${value.toLocaleString('fr-FR')} €`}
+              />
+              <Legend />
+              <Bar dataKey="montant" name="Montant MPR accompagnée" fill="#8884d8" />
+            </BarChart>
+          </ResponsiveContainer>
+        )}
+      </div>
+      
+      <h3>Données détaillées</h3>
+      <table style={{ width: '100%', borderCollapse: 'collapse', marginTop: '20px' }}>
+        <thead>
+          <tr>
+            <th style={{ border: '1px solid #ddd', padding: '8px', textAlign: 'left' }}>Revenu</th>
+            <th style={{ border: '1px solid #ddd', padding: '8px', textAlign: 'left' }}>Montant de l'aide</th>
+          </tr>
+        </thead>
+        <tbody>
+          {results.map((result, index) => (
+            <tr key={index}>
+              <td style={{ border: '1px solid #ddd', padding: '8px' }}>{result.revenue.toLocaleString('fr-FR')} €</td>
+              <td style={{ border: '1px solid #ddd', padding: '8px' }}>{result.formatted}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </section>
-  )
+  );
 }

--- a/app/analyses/Analyses.tsx
+++ b/app/analyses/Analyses.tsx
@@ -1,17 +1,7 @@
 import Engine, { formatValue } from 'publicodes'
 import rules from '@/app/règles/rules'
 import baseSituation from '@/app/analyses/baseSituation.yaml'
-import dynamic from 'next/dynamic'
-
-// Importer recharts avec dynamic import pour éviter les problèmes SSR
-const BarChart = dynamic(() => import('recharts').then(mod => mod.BarChart), { ssr: false })
-const Bar = dynamic(() => import('recharts').then(mod => mod.Bar), { ssr: false })
-const XAxis = dynamic(() => import('recharts').then(mod => mod.XAxis), { ssr: false })
-const YAxis = dynamic(() => import('recharts').then(mod => mod.YAxis), { ssr: false })
-const CartesianGrid = dynamic(() => import('recharts').then(mod => mod.CartesianGrid), { ssr: false })
-const Tooltip = dynamic(() => import('recharts').then(mod => mod.Tooltip), { ssr: false })
-const Legend = dynamic(() => import('recharts').then(mod => mod.Legend), { ssr: false })
-const ResponsiveContainer = dynamic(() => import('recharts').then(mod => mod.ResponsiveContainer), { ssr: false })
+import { OurLineChart } from './LineChart'
 
 // Initialize the publicodes engine once with mesaidesreno rules
 const engine = new Engine(rules)
@@ -38,85 +28,90 @@ function evaluatePublicodesRule(
 
 // Function to generate revenue values from 1000 to 100000
 function generateRevenueValues(count: number) {
-  const min = 1000;
-  const max = 100000;
-  const step = (max - min) / (count - 1);
-  
-  return Array.from({ length: count }, (_, i) => Math.round(min + i * step));
+  const min = 1000
+  const max = 100000
+  const step = (max - min) / (count - 1)
+
+  return Array.from({ length: count }, (_, i) => Math.round(min + i * step))
 }
 
 // Function to evaluate a rule for multiple revenue values
-function evaluateRuleForMultipleRevenues(ruleName: string, revenueValues: number[]) {
-  return revenueValues.map(revenue => {
+function evaluateRuleForMultipleRevenues(
+  ruleName: string,
+  revenueValues: number[],
+) {
+  return revenueValues.map((revenue) => {
     const result = evaluatePublicodesRule(ruleName, {
       ...baseSituation,
       'ménage . revenu': revenue,
-    });
-    
+    })
+
     return {
       revenue: revenue,
       montant: typeof result.value === 'number' ? result.value : 0,
       formatted: result.formatted,
-    };
-  });
+    }
+  })
 }
 
 export default function Analyses() {
   // Generate 10 revenue values from 1000 to 100000
-  const revenueValues = generateRevenueValues(10);
-  
+  const revenueValues = generateRevenueValues(10)
+
   // Evaluate the rule for each revenue value
-  const results = evaluateRuleForMultipleRevenues('MPR . accompagnée . montant', revenueValues);
-  
+  const results = evaluateRuleForMultipleRevenues(
+    'MPR . accompagnée . montant',
+    revenueValues,
+  )
+
   return (
     <section>
       <h2>Analyse de la règle "MPR . accompagnée . montant"</h2>
       <p>Montant de l'aide en fonction du revenu du ménage</p>
-      
-      <div style={{ width: '100%', height: 500, marginTop: 20 }}>
-        {typeof window !== 'undefined' && (
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              layout="vertical"
-              data={results}
-              margin={{ top: 20, right: 30, left: 100, bottom: 5 }}
-            >
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis type="number" label={{ value: 'Montant (€)', position: 'insideBottom', offset: -5 }} />
-              <YAxis 
-                type="category" 
-                dataKey="revenue" 
-                tickFormatter={(value) => `${value.toLocaleString('fr-FR')} €`}
-                label={{ value: 'Revenu du ménage (€)', angle: -90, position: 'insideLeft' }}
-              />
-              <Tooltip 
-                formatter={(value) => [`${value.toLocaleString('fr-FR')} €`, 'Montant de l\'aide']}
-                labelFormatter={(value) => `Revenu: ${value.toLocaleString('fr-FR')} €`}
-              />
-              <Legend />
-              <Bar dataKey="montant" name="Montant MPR accompagnée" fill="#8884d8" />
-            </BarChart>
-          </ResponsiveContainer>
-        )}
+
+      <div style={{ width: '100%', height: 450, marginTop: 20 }}>
+        <OurLineChart data={results} />
       </div>
-      
+
       <h3>Données détaillées</h3>
-      <table style={{ width: '100%', borderCollapse: 'collapse', marginTop: '20px' }}>
+      <table
+        style={{ width: '100%', borderCollapse: 'collapse', marginTop: '2rem' }}
+      >
         <thead>
           <tr>
-            <th style={{ border: '1px solid #ddd', padding: '8px', textAlign: 'left' }}>Revenu</th>
-            <th style={{ border: '1px solid #ddd', padding: '8px', textAlign: 'left' }}>Montant de l'aide</th>
+            <th
+              style={{
+                border: '1px solid #ddd',
+                padding: '8px',
+                textAlign: 'left',
+              }}
+            >
+              Revenu
+            </th>
+            <th
+              style={{
+                border: '1px solid #ddd',
+                padding: '8px',
+                textAlign: 'left',
+              }}
+            >
+              Montant de l'aide
+            </th>
           </tr>
         </thead>
         <tbody>
           {results.map((result, index) => (
             <tr key={index}>
-              <td style={{ border: '1px solid #ddd', padding: '8px' }}>{result.revenue.toLocaleString('fr-FR')} €</td>
-              <td style={{ border: '1px solid #ddd', padding: '8px' }}>{result.formatted}</td>
+              <td style={{ border: '1px solid #ddd', padding: '8px' }}>
+                {result.revenue.toLocaleString('fr-FR')} €
+              </td>
+              <td style={{ border: '1px solid #ddd', padding: '8px' }}>
+                {result.formatted}
+              </td>
             </tr>
           ))}
         </tbody>
       </table>
     </section>
-  );
+  )
 }

--- a/app/analyses/Analyses.tsx
+++ b/app/analyses/Analyses.tsx
@@ -1,36 +1,39 @@
 import Engine from 'publicodes'
-import rules from 'mesaidesreno'
+import rules from '@/app/règles/rules'
 
 // Initialiser le moteur publicodes une seule fois avec les règles de mesaidesreno
 const engine = new Engine(rules)
 
 // Fonction utilitaire pour évaluer une règle publicodes
-function evaluatePublicodesRule(ruleName: string, situation: Record<string, any>) {
+function evaluatePublicodesRule(
+  ruleName: string,
+  situation: Record<string, any>,
+) {
   // Réinitialiser la situation pour éviter les effets de bord
-  engine.resetSituation()
-  
+
   // Définir la situation
   engine.setSituation(situation)
-  
+
   // Évaluer la règle
   const evaluation = engine.evaluate(ruleName)
-  
+
   return {
     value: evaluation.nodeValue,
-    formatted: evaluation.nodeValue !== null ? 
-      `${evaluation.nodeValue} ${evaluation.unit || ''}` : 
-      'Règle non applicable',
-    missingVariables: evaluation.missingVariables
+    formatted:
+      evaluation.nodeValue !== null
+        ? `${evaluation.nodeValue} ${evaluation.unit || ''}`
+        : 'Règle non applicable',
+    missingVariables: evaluation.missingVariables,
   }
 }
 
 export default function Analyses() {
   // Générer un revenu aléatoire entre 10000 et 100000
   const randomRevenu = Math.floor(Math.random() * 90000) + 10000
-  
+
   // Évaluer la règle "MPR . accompagnée . montant" avec le revenu aléatoire
   const result = evaluatePublicodesRule('MPR . accompagnée . montant', {
-    'revenu': randomRevenu
+    'ménage . revenu': randomRevenu,
   })
 
   return (
@@ -42,7 +45,7 @@ export default function Analyses() {
         <div>
           <p>Variables manquantes pour le calcul complet:</p>
           <ul>
-            {Object.keys(result.missingVariables).map(variable => (
+            {Object.keys(result.missingVariables).map((variable) => (
               <li key={variable}>{variable}</li>
             ))}
           </ul>

--- a/app/analyses/Analyses.tsx
+++ b/app/analyses/Analyses.tsx
@@ -1,38 +1,50 @@
-import { useEffect, useState } from 'react'
 import Engine from 'publicodes'
 import rules from 'mesaidesreno'
 
-export default function Analyses() {
-  const [result, setResult] = useState<string | null>(null)
-  const [randomRevenu, setRandomRevenu] = useState<number>(0)
-
-  useEffect(() => {
-    // Générer un revenu aléatoire entre 10000 et 100000
-    const revenu = Math.floor(Math.random() * 90000) + 10000
-    setRandomRevenu(revenu)
-
-    // Initialiser le moteur publicodes avec les règles de mesaidesreno
-    const engine = new Engine(rules)
-    
-    // Définir la situation avec le revenu aléatoire
-    engine.setSituation({
-      'revenu': revenu
-    })
-    
-    // Évaluer la règle "MPR . accompagnée . montant"
-    const evaluation = engine.evaluate('MPR . accompagnée . montant')
-    
-    // Récupérer le résultat formaté
-    setResult(evaluation.nodeValue !== null ? 
+// Fonction utilitaire pour évaluer une règle publicodes
+function evaluatePublicodesRule(ruleName: string, situation: Record<string, any>) {
+  // Initialiser le moteur publicodes avec les règles de mesaidesreno
+  const engine = new Engine(rules)
+  
+  // Définir la situation
+  engine.setSituation(situation)
+  
+  // Évaluer la règle
+  const evaluation = engine.evaluate(ruleName)
+  
+  return {
+    value: evaluation.nodeValue,
+    formatted: evaluation.nodeValue !== null ? 
       `${evaluation.nodeValue} ${evaluation.unit || ''}` : 
-      'Règle non applicable')
-  }, [])
+      'Règle non applicable',
+    missingVariables: evaluation.missingVariables
+  }
+}
+
+export default function Analyses() {
+  // Générer un revenu aléatoire entre 10000 et 100000
+  const randomRevenu = Math.floor(Math.random() * 90000) + 10000
+  
+  // Évaluer la règle "MPR . accompagnée . montant" avec le revenu aléatoire
+  const result = evaluatePublicodesRule('MPR . accompagnée . montant', {
+    'revenu': randomRevenu
+  })
 
   return (
     <section>
       <h2>Analyse de la règle "MPR . accompagnée . montant"</h2>
       <p>Revenu aléatoire utilisé: {randomRevenu} €</p>
-      <p>Résultat de l'évaluation: {result || 'Calcul en cours...'}</p>
+      <p>Résultat de l'évaluation: {result.formatted}</p>
+      {Object.keys(result.missingVariables).length > 0 && (
+        <div>
+          <p>Variables manquantes pour le calcul complet:</p>
+          <ul>
+            {Object.keys(result.missingVariables).map(variable => (
+              <li key={variable}>{variable}</li>
+            ))}
+          </ul>
+        </div>
+      )}
     </section>
   )
 }

--- a/app/analyses/Analyses.tsx
+++ b/app/analyses/Analyses.tsx
@@ -1,0 +1,3 @@
+export default function Analyses() {
+  return <section></section>
+}

--- a/app/analyses/Analyses.tsx
+++ b/app/analyses/Analyses.tsx
@@ -1,5 +1,6 @@
-import Engine from 'publicodes'
+import Engine, { formatValue } from 'publicodes'
 import rules from '@/app/règles/rules'
+import baseSituation from '@/app/analyses/baseSituation.yaml'
 
 // Initialize the publicodes engine once with mesaidesreno rules
 const engine = new Engine(rules)
@@ -19,10 +20,7 @@ function evaluatePublicodesRule(
 
   return {
     value: evaluation.nodeValue,
-    formatted:
-      evaluation.nodeValue !== null
-        ? `${evaluation.nodeValue} ${evaluation.unit || ''}`
-        : 'Rule not applicable',
+    formatted: formatValue(evaluation),
     missingVariables: evaluation.missingVariables,
   }
 }
@@ -33,6 +31,7 @@ export default function Analyses() {
 
   // Evaluate the rule "MPR . accompagnée . montant" with the random income
   const result = evaluatePublicodesRule('MPR . accompagnée . montant', {
+    ...baseSituation,
     'ménage . revenu': randomRevenu,
   })
 

--- a/app/analyses/LineChart.tsx
+++ b/app/analyses/LineChart.tsx
@@ -1,0 +1,65 @@
+'use client'
+
+const mockData = [
+  {
+    name: 'Page A',
+    uv: 4000,
+    pv: 2400,
+    amt: 2400,
+  },
+  {
+    name: 'Page B',
+    uv: 3000,
+    pv: 1398,
+    amt: 2210,
+  },
+  {
+    name: 'Page C',
+    uv: 2000,
+    pv: 9800,
+    amt: 2290,
+  },
+  {
+    name: 'Page D',
+    uv: 2780,
+    pv: 3908,
+    amt: 2000,
+  },
+  {
+    name: 'Page E',
+    uv: 1890,
+    pv: 4800,
+    amt: 2181,
+  },
+  {
+    name: 'Page F',
+    uv: 2390,
+    pv: 3800,
+    amt: 2500,
+  },
+  {
+    name: 'Page G',
+    uv: 3490,
+    pv: 4300,
+    amt: 2100,
+  },
+]
+
+import { LineChart, XAxis, CartesianGrid, Line, YAxis } from 'recharts'
+
+export function OurLineChart({ data }) {
+  console.log('cyan', data)
+  return (
+    <LineChart width={700} height={400} data={data}>
+      <XAxis dataKey="revenue" />
+      <YAxis />
+      <CartesianGrid stroke="#eee" strokeDasharray="5 5" />
+      <Line
+        type="monotone"
+        dataKey="montant"
+        stroke="#000091"
+        strokeWidth={'2px'}
+      />
+    </LineChart>
+  )
+}

--- a/app/analyses/LineChart.tsx
+++ b/app/analyses/LineChart.tsx
@@ -1,65 +1,79 @@
 'use client'
 
-const mockData = [
-  {
-    name: 'Page A',
-    uv: 4000,
-    pv: 2400,
-    amt: 2400,
-  },
-  {
-    name: 'Page B',
-    uv: 3000,
-    pv: 1398,
-    amt: 2210,
-  },
-  {
-    name: 'Page C',
-    uv: 2000,
-    pv: 9800,
-    amt: 2290,
-  },
-  {
-    name: 'Page D',
-    uv: 2780,
-    pv: 3908,
-    amt: 2000,
-  },
-  {
-    name: 'Page E',
-    uv: 1890,
-    pv: 4800,
-    amt: 2181,
-  },
-  {
-    name: 'Page F',
-    uv: 2390,
-    pv: 3800,
-    amt: 2500,
-  },
-  {
-    name: 'Page G',
-    uv: 3490,
-    pv: 4300,
-    amt: 2100,
-  },
-]
+import { 
+  LineChart, 
+  XAxis, 
+  CartesianGrid, 
+  Line, 
+  YAxis, 
+  Tooltip, 
+  Legend, 
+  ResponsiveContainer 
+} from 'recharts'
 
-import { LineChart, XAxis, CartesianGrid, Line, YAxis } from 'recharts'
+// DPE colors
+const dpeColors = {
+  'A': '#319834',
+  'B': '#5eb92d',
+  'C': '#cdcf00',
+  'D': '#fecb02',
+  'E': '#ee8100',
+  'F': '#e84b0f',
+  'G': '#d7221f'
+}
 
 export function OurLineChart({ data }) {
-  console.log('cyan', data)
+  // Get unique revenue values for X axis
+  const allDataPoints = data.flatMap(series => series.data)
+  const uniqueRevenues = [...new Set(allDataPoints.map(item => item.revenue))]
+    .sort((a, b) => a - b)
+  
+  // Transform data for Recharts
+  const transformedData = uniqueRevenues.map(revenue => {
+    const dataPoint = { revenue }
+    
+    // Add a property for each DPE series
+    data.forEach(series => {
+      const matchingPoint = series.data.find(point => point.revenue === revenue)
+      if (matchingPoint) {
+        dataPoint[`DPE ${series.label}`] = matchingPoint.montant
+      }
+    })
+    
+    return dataPoint
+  })
+
   return (
-    <LineChart width={700} height={400} data={data}>
-      <XAxis dataKey="revenue" />
-      <YAxis />
-      <CartesianGrid stroke="#eee" strokeDasharray="5 5" />
-      <Line
-        type="monotone"
-        dataKey="montant"
-        stroke="#000091"
-        strokeWidth={'2px'}
-      />
-    </LineChart>
+    <ResponsiveContainer width="100%" height="100%">
+      <LineChart data={transformedData}>
+        <XAxis 
+          dataKey="revenue" 
+          tickFormatter={(value) => `${(value/1000).toFixed(0)}k€`}
+          label={{ value: 'Revenu du ménage', position: 'insideBottom', offset: -5 }}
+        />
+        <YAxis 
+          label={{ value: 'Montant de l\'aide (€)', angle: -90, position: 'insideLeft' }}
+        />
+        <CartesianGrid stroke="#eee" strokeDasharray="5 5" />
+        <Tooltip 
+          formatter={(value) => [`${value.toLocaleString('fr-FR')} €`, 'Montant']}
+          labelFormatter={(value) => `Revenu: ${value.toLocaleString('fr-FR')} €`}
+        />
+        <Legend />
+        
+        {data.map(series => (
+          <Line
+            key={series.id}
+            type="monotone"
+            dataKey={`DPE ${series.label}`}
+            name={`DPE ${series.label}`}
+            stroke={dpeColors[series.label] || `#${Math.floor(Math.random()*16777215).toString(16)}`}
+            strokeWidth={2}
+            dot={{ r: 4 }}
+            activeDot={{ r: 6 }}
+          />
+        ))}
+      </LineChart>
+    </ResponsiveContainer>
   )
 }

--- a/app/analyses/Tooltip.tsx
+++ b/app/analyses/Tooltip.tsx
@@ -1,0 +1,182 @@
+'use client'
+import * as React from 'react'
+import { createPortal } from 'react-dom'
+
+/* -------------------------------------------------------------------------------------------------
+ * This is a basic tooltip created for the chart demos. Customize as needed or bring your own solution.
+ * -----------------------------------------------------------------------------------------------*/
+
+type TooltipContextValue = {
+  tooltip: { x: number; y: number } | undefined
+  setTooltip: (tooltip: { x: number; y: number } | undefined) => void
+}
+
+const TooltipContext = React.createContext<TooltipContextValue | undefined>(
+  undefined,
+)
+
+function useTooltipContext(componentName: string): TooltipContextValue {
+  const context = React.useContext(TooltipContext)
+  if (!context) {
+    throw new Error('Tooltip must be used within a Tooltip Context')
+  }
+  return context
+}
+
+/* -------------------------------------------------------------------------------------------------
+ * Tooltip
+ * -----------------------------------------------------------------------------------------------*/
+
+const Tooltip: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const [tooltip, setTooltip] = React.useState<{ x: number; y: number }>()
+
+  return (
+    <TooltipContext.Provider value={{ tooltip, setTooltip }}>
+      {children}
+    </TooltipContext.Provider>
+  )
+}
+
+/* -------------------------------------------------------------------------------------------------
+ * TooltipTrigger
+ * -----------------------------------------------------------------------------------------------*/
+
+const TRIGGER_NAME = 'TooltipTrigger'
+
+const TooltipTrigger = React.forwardRef<
+  SVGGElement,
+  { children: React.ReactNode }
+>((props, forwardedRef) => {
+  const { children } = props
+  const context = useTooltipContext(TRIGGER_NAME)
+  const triggerRef = React.useRef<SVGGElement | null>(null)
+
+  React.useEffect(() => {
+    const handleClickOutside = (event: MouseEvent | TouchEvent) => {
+      if (
+        triggerRef.current &&
+        !triggerRef.current.contains(event.target as Node)
+      ) {
+        context.setTooltip(undefined)
+      }
+    }
+
+    document.addEventListener('mousedown', handleClickOutside)
+    document.addEventListener('touchstart', handleClickOutside)
+
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside)
+      document.removeEventListener('touchstart', handleClickOutside)
+    }
+  }, [context])
+
+  return (
+    <g
+      ref={(node) => {
+        // Maintain both refs
+        triggerRef.current = node
+        if (typeof forwardedRef === 'function') {
+          forwardedRef(node)
+        } else if (forwardedRef) {
+          forwardedRef.current = node
+        }
+      }}
+      onPointerMove={(event) => {
+        // Only handle mouse events, not touch
+        if (event.pointerType === 'mouse') {
+          context.setTooltip({ x: event.clientX, y: event.clientY })
+        }
+      }}
+      onPointerLeave={(event) => {
+        // Only handle mouse events, not touch
+        if (event.pointerType === 'mouse') {
+          context.setTooltip(undefined)
+        }
+      }}
+      onTouchStart={(event) => {
+        // On mobile, trigger when clicked instead of hover. Change as needed.
+        context.setTooltip({
+          x: event.touches[0].clientX,
+          y: event.touches[0].clientY,
+        })
+        setTimeout(() => {
+          context.setTooltip(undefined)
+        }, 2000)
+      }}
+    >
+      {children}
+    </g>
+  )
+})
+
+TooltipTrigger.displayName = TRIGGER_NAME
+
+/* -------------------------------------------------------------------------------------------------
+ * TooltipContent
+ * -----------------------------------------------------------------------------------------------*/
+
+const CONTENT_NAME = 'TooltipContent'
+
+const TooltipContent = React.forwardRef<
+  HTMLDivElement,
+  { children: React.ReactNode }
+>((props, forwardedRef) => {
+  const { children } = props
+  const context = useTooltipContext(CONTENT_NAME)
+  const runningOnClient = typeof document !== 'undefined'
+  const tooltipRef = React.useRef<HTMLDivElement>(null)
+
+  // Calculate position based on viewport
+  const getTooltipPosition = () => {
+    if (!tooltipRef.current || !context.tooltip) return {}
+
+    const tooltipWidth = tooltipRef.current.offsetWidth
+    const viewportWidth = window.innerWidth
+    const willOverflowRight =
+      context.tooltip.x + tooltipWidth + 10 > viewportWidth
+
+    return {
+      top: context.tooltip.y - 20,
+      left: willOverflowRight
+        ? context.tooltip.x - tooltipWidth - 10
+        : context.tooltip.x + 10,
+    }
+  }
+
+  if (!context.tooltip || !runningOnClient) {
+    return null
+  }
+
+  const isMobile = window.innerWidth < 768
+
+  return createPortal(
+    isMobile ? (
+      <div
+        className="fixed h-fit z-60 w-fit rounded-lg bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 p-3"
+        style={{
+          top: context.tooltip.y,
+          left: context.tooltip.x + 20,
+        }}
+      >
+        {children}
+      </div>
+    ) : (
+      <div
+        ref={tooltipRef}
+        className="bg-white dark:bg-zinc-900 border border-zinc-200 dark:border-zinc-800 px-3.5 py-2 rounded-sm fixed z-50"
+        style={getTooltipPosition()}
+      >
+        {children}
+      </div>
+    ),
+    document.body,
+  )
+})
+
+TooltipContent.displayName = CONTENT_NAME
+
+/* -------------------------------------------------------------------------------------------------
+ * Exports
+ * -----------------------------------------------------------------------------------------------*/
+
+export { Tooltip as ClientTooltip, TooltipTrigger, TooltipContent }

--- a/app/analyses/baseSituation.yaml
+++ b/app/analyses/baseSituation.yaml
@@ -1,0 +1,14 @@
+ménage . personnes: 3
+DPE . actuel: 6
+projet . DPE visé: 2
+projet . travaux: 70140 / (1.055)
+ménage . code région: "'27'"
+ménage . code département: "'25'" # Doubs / Zone climatique H1
+ménage . commune: "'25388'"
+ménage . EPCI: "'200065647'"
+vous . propriétaire . condition: oui
+logement . propriétaire occupant: oui
+logement . résidence principale propriétaire: oui
+logement . type: "'maison'"
+logement . surface: 91
+logement . période de construction: "'au moins 15 ans'"

--- a/app/analyses/page.tsx
+++ b/app/analyses/page.tsx
@@ -1,0 +1,39 @@
+import css from '@/components/css/convertToJs'
+import dynamic from '@/node_modules/next/dynamic'
+import logo from '@/app/icon.svg'
+import Image from 'next/image'
+import Analyses from './Analyses'
+
+export default function Page(props) {
+  return (
+    <main
+      style={css`
+        width: 700px;
+        max-width: 96vw;
+        padding: 0 0.6rem;
+        margin: 0 auto;
+      `}
+    >
+      <header
+        style={css`
+          display: flex;
+          align-items: center;
+        `}
+      >
+        <Image
+          src={logo}
+          alt="Logo Mes Aides Rénovation 2024"
+          style={css`
+            width: 2rem;
+            margin-right: 0.6rem;
+            height: auto;
+            padding-top: 0.5rem;
+          `}
+        />
+        <h1>Analyses</h1>
+      </header>
+      <p>Analyses sur la base du modèle Mes Aides Réno</p>
+      <Analyses />
+    </main>
+  )
+}

--- a/app/analyses/page.tsx
+++ b/app/analyses/page.tsx
@@ -1,6 +1,5 @@
-import css from '@/components/css/convertToJs'
-import dynamic from '@/node_modules/next/dynamic'
 import logo from '@/app/icon.svg'
+import css from '@/components/css/convertToJs'
 import Image from 'next/image'
 import Analyses from './Analyses'
 

--- a/app/règles/gestes/chauffage/PAC.yaml
+++ b/app/règles/gestes/chauffage/PAC.yaml
@@ -425,15 +425,15 @@ chauffage . PAC . air-air . CEE . SCOP:
   une possibilité parmi:
     possibilités:
       - 'inferieur à 4'
-      - 'inferieur à 4.3'
-      - 'superieur à 4.3'
+      - 'inferieur à 4point3'
+      - 'superieur à 4point3'
 chauffage . PAC . air-air . CEE . SCOP . inferieur à 4:
   valeur: '3'
   titre: 'Inférieur à 3.9'
-chauffage . PAC . air-air . CEE . SCOP . inferieur à 4.3:
+chauffage . PAC . air-air . CEE . SCOP . inferieur à 4point3:
   valeur: '4'
   titre: 'Inférieur à 4.3'
-chauffage . PAC . air-air . CEE . SCOP . superieur à 4.3:
+chauffage . PAC . air-air . CEE . SCOP . superieur à 4point3:
   valeur: '5'
   titre: 'Supérieur à 4.3'
 chauffage . PAC . air-air . CEE . surface: logement . surface

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "maplibre-gl": "^4.1.1",
     "marked": "^12.0.1",
     "marked-plaintify": "^1.0.1",
+    "mesaidesreno": "^2.1.0",
     "micromark": "^4.0.0",
     "next": "^15.1.3",
     "next-contentlayer2": "^0.5.3",


### PR DESCRIPTION
- **feat: Add Analyses component to app**
- **feat: Add publicodes rule evaluation with random revenue in Analyses component**
- **refactor: Remove useEffect, compute Publicodes rule synchronously**
- **refactor: Initialize Publicodes engine once and reset situation per evaluation**
- **refactor: Update Publicodes rule evaluation and import path**
- **docs: Translate front-end texts in Analyses.tsx from French to English**
- **Problème publicodes sur le point dans le nom**
- **Nouvelle page /analyses pour la démo Rules as Code**
- **feat: Add horizontal bar chart for revenue analysis using Recharts**
- **Aider n'a pas bien bossé, on reprend la main**
- **feat: Add multiple DPE lines to MPR aid amount chart**
