### PR TITLE
Correction review module valeur verte

### DIFF
--- a/app/module/AmpleurCTA.tsx
+++ b/app/module/AmpleurCTA.tsx
@@ -18,9 +18,7 @@ export default function AmpleurCTA({
   const url = situationToCtaUrl(situation)
   return (
     <Link href={url} target={target}>
-      <span>
-        {isMobile ? textMobile : text}&nbsp;{!isMobile && <>⚡️&nbsp;</>}➞
-      </span>
+      <span>{isMobile ? textMobile : text}&nbsp;⚡️&nbsp;➞</span>
     </Link>
   )
 }

--- a/app/module/valeur-verte/examplePersonasValeurVerte.yaml
+++ b/app/module/valeur-verte/examplePersonasValeurVerte.yaml
@@ -14,5 +14,5 @@
   situation:
     DPE . actuel: 5
     logement . prix d'achat: 350000
-    logement . commune: 01033
+    logement . commune: '01033'
     logement . type: '"maison"'

--- a/components/module/ValeurVerteModule.tsx
+++ b/components/module/ValeurVerteModule.tsx
@@ -184,7 +184,8 @@ export default function ValeurVerteModule({ type, lettre }) {
             ${isMobile && 'font-size: 105% !important;'}
           `}
         >
-          <span aria-hidden="true">💶</span> Après rénovation, mon bien vaudra
+          <span aria-hidden="true">💶</span> Après rénovation
+          {!isMobile ? ' énergétique' : ''}, mon bien vaudra
           {!isMobile && ' :'}{' '}
         </h2>
         {plusValue != 0 && !isNaN(plusValue) && (

--- a/components/module/ValeurVerteModule.tsx
+++ b/components/module/ValeurVerteModule.tsx
@@ -151,32 +151,34 @@ export default function ValeurVerteModule({ type, lettre }) {
             text={'Et il a une étiquette DPE'}
           />
         </Li>
-        <Li
-          $next={answeredQuestions.includes('DPE . actuel')}
-          $touched={answeredQuestions.includes('projet . DPE visé')}
-        >
-          <Dot />
-          <span
-            css={`
-              li {
-                margin: 0 !important;
-              }
-            `}
+        {situation['DPE . actuel'] > 2 && (
+          <Li
+            $next={answeredQuestions.includes('DPE . actuel')}
+            $touched={answeredQuestions.includes('projet . DPE visé')}
           >
-            <TargetDPETabs
-              {...{
-                oldIndex: situation['DPE . actuel'] - 1,
-                setSearchParams,
-                answeredQuestions,
-                choice: situation['projet . DPE visé'] - 1,
-                engine,
-                situation,
-                columnDisplay: isMobile,
-                text: 'Après les travaux, je vise',
-              }}
-            />
-          </span>
-        </Li>
+            <Dot />
+            <span
+              css={`
+                li {
+                  margin: 0 !important;
+                }
+              `}
+            >
+              <TargetDPETabs
+                {...{
+                  oldIndex: situation['DPE . actuel'] - 1,
+                  setSearchParams,
+                  answeredQuestions,
+                  choice: Math.max(1, situation['projet . DPE visé'] - 1),
+                  engine,
+                  situation,
+                  columnDisplay: isMobile,
+                  text: 'Après les travaux, je vise',
+                }}
+              />
+            </span>
+          </Li>
+        )}
       </QuestionList>
       <EvaluationValueWrapper $active={plusValue != 0 && !isNaN(plusValue)}>
         <h2
@@ -188,7 +190,12 @@ export default function ValeurVerteModule({ type, lettre }) {
           {!isMobile ? ' énergétique' : ''}, mon bien vaudra
           {!isMobile && ' :'}{' '}
         </h2>
-        {plusValue != 0 && !isNaN(plusValue) && (
+        {situation['DPE . actuel'] <= 2 ? (
+          <>
+            🤔 Nous ne pouvons estimer l'impact d'une rénovation sur les biens
+            classés <DPELabel index="0" /> ou <DPELabel index="1" />
+          </>
+        ) : plusValue != 0 && !isNaN(plusValue) ? (
           <>
             <div
               css={`
@@ -214,6 +221,11 @@ export default function ValeurVerteModule({ type, lettre }) {
                 region,
               }}
             />
+          </>
+        ) : (
+          <>
+            🤔 Répondez aux questions pour connaître la valeur verte de votre
+            bien
           </>
         )}
         {isNaN(plusValue) && (


### PR DESCRIPTION
Petite PR pour traiter les retours de Louis et Claire sur le module valeur verte:
- [x]  les CTA desktop et mobile sont différents (avec et sans *⚡️)*, c’est un choix ?
- [x]  blank state → le background est déjà jaune, peut on aussi changer le texte ?
    - [x]  🤔 Répondez aux questions pour connaître la valeur verte de votre bien
- [x]  modification des mots des résultats par Claire :
    `💶 Après rénovation, mon bien vaudra :`  →    `💶 Après rénovation énergétique, mon bien vaudra :`
- [ ]  le code de l’iframe ne renvoie pas vers un blank state du module, est-ce que ça ne devrait pas être le cas ?
- [x]  bug / non pris en charge : l’exemple 3 Maison classé en E à Valserhône ne remplit pas correctement le formulaire
- [x]  bug / non pris en charge : si je choisis un DPE A alors le % d’augmentation est de 0% et on m’affiche une comparaison entre DPE B et B. Est-ce qu’on veut le gérer ?