### PR TITLE
Option de redimensionnement automatique des iframes désactivée par

### DIFF
--- a/components/IntegrationQuestions.tsx
+++ b/components/IntegrationQuestions.tsx
@@ -38,7 +38,7 @@ export default function IntegrationQuestions({
           ></iframe>
         </div>
       </details>
-      {noScroll && setNoScroll && (
+      {noScroll != null && setNoScroll && (
         <details>
           <summary>Comment cacher la barre de défilement verticale ?</summary>
           <div>


### PR DESCRIPTION
erreur

Enfin j'imagine, je ne pige pas pourquoi elle a marché pour la démo quand je l'ai implémentée.