### PR TITLE
Test d'intégration d'un sondage Tally sur une question

### DIFF
--- a/components/ClassicQuestionWrapper.tsx
+++ b/components/ClassicQuestionWrapper.tsx
@@ -92,7 +92,7 @@ export default function ClassicQuestionWrapper({
           <Script src="https://tally.so/widgets/embed.js"></Script>{' '}
           <Script
             id={tallyForm}
-          >{` window.TallyConfig = { "formId": ${tallyForm}, "popup": { "emoji": { "text": "👋", "animation": "wave" }, "open": { "trigger": "exit" } } }; `}</Script>
+          >{` window.TallyConfig = { "formId": "${tallyForm}", "popup": { "emoji": { "text": "👋", "animation": "wave" }, "open": { "trigger": "exit" } } }; `}</Script>
         </>
       )}
       <QuestionCard>


### PR DESCRIPTION
Premier test pour #425, sur le premier formulaire Tally, à valider avant d'intégrer les autres formulaires. 

OK je remarque que c'est sur Vercel que la saisie d'adresse ne marche plus, d'où le PB sur la PR DSFR, qui n'a rien à voir; 

[URL de test](https://reno-4v3zj270i-mesaidesreno.vercel.app/simulation?ménage.personnes=3*&ménage.revenu=25000*&DPE.actuel=6*&projet.DPE+visé=2*&logement.code+région="52"*&logement.code+département="44"*&ménage.commune='25388'*&ménage.EPCI='200065647'*&vous.propriétaire.condition=oui*&logement.propriétaire+occupant=oui*&logement.résidence+principale+propriétaire=oui*&logement.type='maison'*&logement.surface=91*&logement.période+de+construction='au+moins+15+ans'*&gestes.isolation.murs+extérieurs.MPR.surface=85*&gestes.isolation.murs+intérieurs.MPR.surface=85*&gestes.isolation.rampants.MPR.surface=60*&gestes.isolation.toitures+terrasses.MPR.surface=60*&gestes.isolation.vitres.MPR.quantité=5*&gestes.isolation.vitres.CEE.surface=6*&gestes.chauffage.bois.foyer+et+insert.CEE.Etas='entre+66+%25+et+72+%25'*&gestes.chauffage.bois.poêle.à+bûches.CEE.Etas='entre+72+%25+et+80+%25'*&gestes.chauffage.bois.poêle.à+granulés.CEE.Etas='supérieur+à+80+%25'*&CEE.projet.remplacement+chaudière+thermique=oui*&logement.commune.denormandie=non*&taxe+foncière.commune.éligible=oui*&logement.commune.nom="NANTES"*&logement.adresse="18+Rue+de+Nancy+44300+Nantes"&logement.EPCI="244400404"&logement.commune="44109"&logement.coordonnees="47.243539%2C-1.526003"&taxe+foncière.commune.taux=50+%25)

C'est une première intégration : à mon avis si l'utilisateur veut quitter le site après la question le formulaire apparaitra quand même, il faudra corriger ça pour mettre les autres formulaires à la place dans la suite du parcours, je sais pas encore comment.

![Recording 2025-08-14 at 17 31 03](https://github.com/user-attachments/assets/7c2501ba-515e-4528-be5f-48e91e600b2c)
