### PR TITLE
feat: retirer l’éligibilité MPR Geste pour isolations murs et chaudières bois

### DIFF
--- a/app/personas.yaml
+++ b/app/personas.yaml
@@ -16,8 +16,8 @@
     logement . type: "'maison'"
     logement . surface: 91
     logement . période de construction: "'au moins 15 ans'"
-    gestes . isolation . murs extérieurs . MPR . surface: 85
-    gestes . isolation . murs intérieurs . MPR . surface: 85
+    gestes . isolation . murs extérieurs . CEE . surface: 85
+    gestes . isolation . murs intérieurs . CEE . surface: 85
     gestes . isolation . rampants . MPR . surface: 60
     gestes . isolation . toitures terrasses . MPR . surface: 60
     gestes . isolation . vitres . MPR . quantité: 5
@@ -42,18 +42,14 @@
     gestes . ventilation . double flux . MPR . montant: 2500
     gestes . isolation . vitres . MPR . montant: 500
     gestes . isolation . vitres . CEE . montant: 182.4
-    gestes . isolation . murs extérieurs . MPR . montant: 6375
     gestes . isolation . murs extérieurs . CEE . montant: 1088
-    gestes . isolation . murs intérieurs . MPR . montant: 2125
     gestes . isolation . murs intérieurs . CEE . montant: 1088
     gestes . isolation . rampants . MPR . montant: 1500
     gestes . isolation . rampants . CEE . montant: 816
     gestes . isolation . toitures terrasses . MPR . montant: 4500
     gestes . isolation . toitures terrasses . CEE . montant: 576
-    gestes . chauffage . bois . chaudière . manuelle . MPR . montant: 3750
     gestes . chauffage . bois . chaudière . manuelle . Coup de pouce . montant: 4000
     gestes . chauffage . bois . chaudière . manuelle . CEE . montant: 0
-    gestes . chauffage . bois . chaudière . automatique . MPR . montant: 5000
     gestes . chauffage . bois . chaudière . automatique . Coup de pouce . montant: 4000
     gestes . chauffage . bois . chaudière . automatique . CEE . montant: 0
     gestes . chauffage . bois . foyer et insert . MPR . montant: 1250
@@ -90,8 +86,8 @@
     logement . type: "'maison'"
     logement . surface: 110
     logement . période de construction: "'au moins 15 ans'"
-    gestes . isolation . murs extérieurs . MPR . surface: 85
-    gestes . isolation . murs intérieurs . MPR . surface: 85
+    gestes . isolation . murs extérieurs . CEE . surface: 85
+    gestes . isolation . murs intérieurs . CEE . surface: 85
     gestes . isolation . rampants . MPR . surface: 60
     gestes . isolation . toitures terrasses . MPR . surface: 60
     gestes . isolation . vitres . MPR . quantité: 5
@@ -119,16 +115,12 @@
     gestes . ventilation . double flux . MPR . montant: 1500
     gestes . isolation . vitres . MPR . montant: 200
     gestes . isolation . vitres . CEE . montant: 148.8
-    gestes . isolation . murs extérieurs . MPR . montant: 3400
     gestes . isolation . murs extérieurs . CEE . montant: 884
-    gestes . isolation . murs intérieurs . MPR . montant: 1275
     gestes . isolation . murs intérieurs . CEE . montant: 884
     gestes . isolation . rampants . MPR . montant: 900
     gestes . isolation . rampants . CEE . montant: 672
     gestes . isolation . toitures terrasses . MPR . montant: 2400
-    gestes . chauffage . bois . chaudière . manuelle . MPR . montant: 1400
     gestes . chauffage . bois . chaudière . manuelle . Coup de pouce . montant: 2500
-    gestes . chauffage . bois . chaudière . automatique . MPR . montant: 2100
     gestes . chauffage . bois . chaudière . automatique . Coup de pouce . montant: 2500
     gestes . chauffage . bois . foyer et insert . MPR . montant: 500
     gestes . chauffage . bois . foyer et insert . CEE . montant: 154.4
@@ -161,8 +153,8 @@
     logement . type: "'appartement'"
     logement . surface: 65
     logement . période de construction: "'au moins 15 ans'"
-    gestes . isolation . murs extérieurs . MPR . surface: 85
-    gestes . isolation . murs intérieurs . MPR . surface: 85
+    gestes . isolation . murs extérieurs . CEE . surface: 85
+    gestes . isolation . murs intérieurs . CEE . surface: 85
     gestes . isolation . rampants . MPR . surface: 60
     gestes . isolation . toitures terrasses . MPR . surface: 60
     gestes . isolation . vitres . MPR . quantité: 5
@@ -188,16 +180,12 @@
     gestes . ventilation . double flux . MPR . montant: 2000
     gestes . isolation . vitres . MPR . montant: 400
     gestes . isolation . vitres . CEE . montant: 100.8
-    gestes . isolation . murs extérieurs . MPR . montant: 5100
     gestes . isolation . murs extérieurs . CEE . montant: 598.4
-    gestes . isolation . murs intérieurs . MPR . montant: 1700
     gestes . isolation . murs intérieurs . CEE . montant: 598.4
     gestes . isolation . rampants . MPR . montant: 1200
     gestes . isolation . rampants . CEE . montant: 432
     gestes . isolation . toitures terrasses . MPR . montant: 3600
-    gestes . chauffage . bois . chaudière . manuelle . MPR . montant: 3150
     gestes . chauffage . bois . chaudière . manuelle . Coup de pouce . montant: 4000
-    gestes . chauffage . bois . chaudière . automatique . MPR . montant: 3850
     gestes . chauffage . bois . chaudière . automatique . Coup de pouce . montant: 4000
     gestes . chauffage . bois . foyer et insert . MPR . montant: 750
     gestes . chauffage . bois . foyer et insert . CEE . montant: 40.8
@@ -292,8 +280,8 @@
     logement . type: "'maison'"
     logement . surface: 91
     logement . période de construction: "'au moins 15 ans'"
-    gestes . isolation . murs extérieurs . MPR . surface: 85
-    gestes . isolation . murs intérieurs . MPR . surface: 85
+    gestes . isolation . murs extérieurs . CEE . surface: 85
+    gestes . isolation . murs intérieurs . CEE . surface: 85
     gestes . isolation . rampants . MPR . surface: 60
     gestes . isolation . toitures terrasses . MPR . surface: 60
     gestes . isolation . vitres . MPR . quantité: 5
@@ -341,8 +329,8 @@
     logement . type: "'maison'"
     logement . surface: 110
     logement . période de construction: "'au moins 15 ans'"
-    gestes . isolation . murs extérieurs . MPR . surface: 85
-    gestes . isolation . murs intérieurs . MPR . surface: 85
+    gestes . isolation . murs extérieurs . CEE . surface: 85
+    gestes . isolation . murs intérieurs . CEE . surface: 85
     gestes . isolation . rampants . MPR . surface: 60
     gestes . isolation . toitures terrasses . MPR . surface: 60
     gestes . isolation . vitres . MPR . quantité: 5
@@ -389,8 +377,8 @@
     logement . type: "'appartement'"
     logement . surface: 65
     logement . période de construction: "'au moins 15 ans'"
-    gestes . isolation . murs extérieurs . MPR . surface: 85
-    gestes . isolation . murs intérieurs . MPR . surface: 85
+    gestes . isolation . murs extérieurs . CEE . surface: 85
+    gestes . isolation . murs intérieurs . CEE . surface: 85
     gestes . isolation . rampants . MPR . surface: 60
     gestes . isolation . toitures terrasses . MPR . surface: 60
     gestes . isolation . vitres . MPR . quantité: 5

--- a/app/règles/gestes/bonus-outre-mer/murs.publicodes
+++ b/app/règles/gestes/bonus-outre-mer/murs.publicodes
@@ -3,7 +3,7 @@ isolation . murs intérieurs . bonus outre-mer . montant:
   applicable si: outre-mer . DROM
   produit:
     - barème
-    - MPR . surface
+    - CEE . surface
 isolation . murs intérieurs . bonus outre-mer . barème: murs . bonus outre-mer . barème commun
 
 isolation . murs extérieurs . bonus outre-mer:
@@ -11,7 +11,7 @@ isolation . murs extérieurs . bonus outre-mer . montant:
   applicable si: outre-mer . DROM
   produit:
     - barème
-    - MPR . surface
+    - CEE . surface
 isolation . murs extérieurs . bonus outre-mer . barème: murs . bonus outre-mer . barème commun
 
 isolation . murs . bonus outre-mer:

--- a/app/règles/gestes/chauffage/bois.yaml
+++ b/app/règles/gestes/chauffage/bois.yaml
@@ -29,26 +29,10 @@ chauffage . bois . chaudière . manuelle:
     En savoir plus sur [France-Rénov](https://france-renov.gouv.fr/renovation/chauffage/chaudiere-buches).
   par défaut: oui
 chauffage . bois . chaudière . manuelle . montant:
-  applicable si:
-    une de ces conditions:
-      - MPR . non accompagnée . éligible
-      - CEE . conditions
+  applicable si: CEE . conditions
   somme:
-    - MPR . montant
     - CEE . montant
     - Coup de pouce . montant
-chauffage . bois . chaudière . manuelle . MPR:
-chauffage . bois . chaudière . manuelle . MPR . plafond: 16000 €
-chauffage . bois . chaudière . manuelle . MPR . montant:
-  applicable si: MPR . non accompagnée . éligible
-  variations:
-    - si: ménage . revenu . classe = 'très modeste'
-      alors: 3750 €
-    - si: ménage . revenu . classe = 'modeste'
-      alors: 3150 €
-    - si: ménage . revenu . classe = 'intermédiaire'
-      alors: 1400 €
-    - sinon: 0 €
 chauffage . bois . chaudière . manuelle . Coup de pouce:
 chauffage . bois . chaudière . manuelle . Coup de pouce . montant:
   applicable si:
@@ -101,26 +85,10 @@ chauffage . bois . chaudière . automatique:
   description: Chaudière bois à alimentation automatique (granulés, plaquettes)
   par défaut: oui
 chauffage . bois . chaudière . automatique . montant:
-  applicable si:
-    une de ces conditions:
-      - MPR . non accompagnée . éligible
-      - CEE . conditions
+  applicable si: CEE . conditions
   somme:
-    - MPR . montant
     - CEE . montant
     - Coup de pouce . montant
-chauffage . bois . chaudière . automatique . MPR:
-chauffage . bois . chaudière . automatique . MPR . plafond: 18000 €
-chauffage . bois . chaudière . automatique . MPR . montant:
-  applicable si: MPR . non accompagnée . éligible
-  variations:
-    - si: ménage . revenu . classe = 'très modeste'
-      alors: 5000 €
-    - si: ménage . revenu . classe = 'modeste'
-      alors: 3850 €
-    - si: ménage . revenu . classe = 'intermédiaire'
-      alors: 2100 €
-    - sinon: 0 €
 chauffage . bois . chaudière . automatique . Coup de pouce:
 chauffage . bois . chaudière . automatique . Coup de pouce . montant:
   applicable si:

--- a/app/règles/gestes/isolation.yaml
+++ b/app/règles/gestes/isolation.yaml
@@ -105,50 +105,27 @@ isolation . murs extérieurs:
   titre: Isolation des murs par l'extérieur
   par défaut: oui
 isolation . murs extérieurs . montant:
-  applicable si:
-    une de ces conditions:
-      - MPR . non accompagnée . éligible
-      - CEE . conditions
+  applicable si: CEE . conditions
   somme:
-    - MPR . montant
     - CEE . montant
     - bonus outre-mer . montant
-isolation . murs extérieurs . MPR:
-isolation . murs extérieurs . MPR . surface:
-  question: Quelle surface de murs extérieurs voulez-vous isoler ?
-  unité: m2
-isolation . murs extérieurs . MPR . plafond: 150 €/m2
-isolation . murs extérieurs . MPR . montant:
-  applicable si: MPR . non accompagnée . éligible
-  produit:
-    - le minimum de:
-        - surface
-        - 100 m2
-    - barème
-isolation . murs extérieurs . MPR . question: surface
-isolation . murs extérieurs . MPR . barème:
-  variations:
-    - si: ménage . revenu . classe = 'très modeste'
-      alors: 75 €/m2
-    - si: ménage . revenu . classe = 'modeste'
-      alors: 60 €/m2
-    - si: ménage . revenu . classe = 'intermédiaire'
-      alors: 40 €/m2
-    - sinon: 0 €
 isolation . murs extérieurs . CEE:
   code: BAR-EN-102
   titre: Isolation des murs
   lien: https://www.ecologie.gouv.fr/sites/default/files/documents/BAR-EN-102%20vA65-4%20%C3%A0%20compter%20du%2001-01-2025.pdf
   technique: |
     La résistance thermique **R** de l'isolation installée (la résistance thermique de l'isolation existante n'étant pas, le cas échéant, prise en compte) est supérieure ou égale à **3,7 m2.K/W**.
+isolation . murs extérieurs . CEE . surface:
+  question: Quelle surface de murs extérieurs voulez-vous isoler ?
+  unité: m2
 isolation . murs extérieurs . CEE . question:
   type: liste
   valeurs:
-    - MPR . surface
+    - CEE . surface
 isolation . murs extérieurs . CEE . montant:
   applicable si: CEE . conditions
   produit:
-    - MPR . surface
+    - CEE . surface
     - barème
     - CEE . prix kWh Cumac
   unité: €
@@ -165,48 +142,27 @@ isolation . murs intérieurs:
   titre: Isolation des murs par l'intérieur
   par défaut: oui
 isolation . murs intérieurs . montant:
-  applicable si:
-    une de ces conditions:
-      - MPR . non accompagnée . éligible
-      - CEE . conditions
+  applicable si: CEE . conditions
   somme:
-    - MPR . montant
     - CEE . montant
     - bonus outre-mer . montant
-isolation . murs intérieurs . MPR:
-isolation . murs intérieurs . MPR . surface:
-  question: Quelle surface de murs intérieurs voulez-vous isoler ?
-  unité: m2
-isolation . murs intérieurs . MPR . plafond: 70 €/m2
-isolation . murs intérieurs . MPR . montant:
-  applicable si: MPR . non accompagnée . éligible
-  produit:
-    - surface
-    - barème
-isolation . murs intérieurs . MPR . question: surface
-isolation . murs intérieurs . MPR . barème:
-  variations:
-    - si: ménage . revenu . classe = 'très modeste'
-      alors: 25 €/m2
-    - si: ménage . revenu . classe = 'modeste'
-      alors: 20 €/m2
-    - si: ménage . revenu . classe = 'intermédiaire'
-      alors: 15 €/m2
-    - sinon: 0 €
 isolation . murs intérieurs . CEE:
   code: BAR-EN-102
   titre: Isolation des murs
   lien: https://www.ecologie.gouv.fr/sites/default/files/documents/BAR-EN-102%20vA65-4%20%C3%A0%20compter%20du%2001-01-2025.pdf
   technique: |
     La résistance thermique **R** de l'isolation installée (la résistance thermique de l'isolation existante n'étant pas, le cas échéant, prise en compte) est supérieure ou égale à **3,7 m².K/W**.
+isolation . murs intérieurs . CEE . surface:
+  question: Quelle surface de murs intérieurs voulez-vous isoler ?
+  unité: m2
 isolation . murs intérieurs . CEE . question:
   type: liste
   valeurs:
-    - MPR . surface
+    - CEE . surface
 isolation . murs intérieurs . CEE . montant:
   applicable si: CEE . conditions
   produit:
-    - MPR . surface
+    - CEE . surface
     - barème
     - CEE . prix kWh Cumac
   unité: €

--- a/components/Eligibility.tsx
+++ b/components/Eligibility.tsx
@@ -21,7 +21,7 @@ import { useAides } from './ampleur/useAides'
 import { AvanceTMO } from './mprg/BlocAideMPR'
 import { decodeDottedName } from './publicodes/situationUtils'
 import useIsInIframe from './useIsInIframe'
-import { categories, getCurDate, getRulesByCategory } from './utils'
+import { categories, getCurDate, getRulesByCategoryByTypes } from './utils'
 import { textValueEquality } from './publicodes/utils'
 import useIsMobile from './useIsMobile'
 import ExplicationCoproprieteContent from './copropriete/ExplicationCoproprieteContent'
@@ -776,7 +776,7 @@ export function TravauxInconnus({
       [category]: !prev[category],
     }))
   }
-  const rulesByCategory = getRulesByCategory(rules, 'MPR')
+  const rulesByCategory = getRulesByCategoryByTypes(rules, ['MPR','CEE']);
   return Object.keys(rulesByCategory).map((category) => (
     <div key={category}>
       <h3 className="fr-mt-10v fr-h5">{category}</h3>


### PR DESCRIPTION
Appliquer les changements prévus pour la mise en production du 01/01/2026:

Supprimer l'éligibilité à MPR Geste de l'ensemble des gestes d'isolations des murs par l'extérieur
Supprimer l'éligibilité à MPR Geste de l'ensemble des gestes d'isolations des murs par l'intérieur
Supprimer l'éligibilité à MPR Geste de l’installation de chaudières à alimentation automatique fonctionnant au bois ou autres biomasse
Supprimer l'éligibilité à MPR Geste de l’installation de chaudières à alimentation manuelle fonctionnant au bois ou autres biomasse